### PR TITLE
fix openai_key env variables app

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ by adding `llm_composer` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:llm_composer, "~> 0.1.0"}
+    {:llm_composer, "~> 0.2.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To create a basic chatbot using LlmComposer, you need to define a module that us
 
 
 ```elixir
-Application.put_env(:llm_caller, :openai_key, "<your api key>")
+Application.put_env(:llm_composer, :openai_key, "<your api key>")
 
 defmodule MyChat do
 
@@ -68,7 +68,7 @@ Make sure to start the Ollama server first.
 
 ```elixir
 # Set the Ollama URI in the application environment if not already configured
-# Application.put_env(:llm_caller, :ollama_uri, "http://localhost:11434")
+# Application.put_env(:llm_composer, :ollama_uri, "http://localhost:11434")
 
 defmodule MyChat do
 
@@ -115,7 +115,7 @@ You can enhance the bot's capabilities by adding support for external function e
 
 
 ```elixir
-Application.put_env(:llm_caller, :openai_key, "<your api key>")
+Application.put_env(:llm_composer, :openai_key, "<your api key>")
 
 defmodule MyChat do
 

--- a/lib/llm_composer/models/open_ai.ex
+++ b/lib/llm_composer/models/open_ai.ex
@@ -38,7 +38,7 @@ defmodule LlmComposer.Models.OpenAI do
     model = Keyword.get(opts, :model)
 
     headers = [
-      {"Authorization", "Bearer " <> Application.get_env(:llm_caller, :openai_key)}
+      {"Authorization", "Bearer " <> Application.get_env(:llm_composer, :openai_key)}
     ]
 
     if model do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LlmComposer.MixProject do
   def project do
     [
       app: :llm_composer,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
The following warning appeared when setting `:openai_key` with `:llm_caller` instead of `:llm_composer,` as it has to match the `app` name.

> 
> You have configured application :llm_caller in your configuration file,
> but the application is not available.
> 
> This usually means one of:
> 
>   1. You have not added the application as a dependency in a mix.exs file.
> 
>   2. You are configuring an application that does not really exist.
> 
> Please ensure :llm_caller exists or remove the configuration.