### PR TITLE
Change reference branch for docs to master

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,8 @@ defmodule LlmComposer.MixProject do
       package: package(),
       docs: [
         main: "readme",
-        extras: ["README.md"]
+        extras: ["README.md"],
+        source_ref: "master"
       ],
       source_url: "https://github.com/doofinder/llm_composer"
     ]


### PR DESCRIPTION
The default reference branch for ExDoc is `main` and source links were broken. This fixes source links to github :rocket: 