### PR TITLE
Handle errors such as timeouts

### DIFF
--- a/lib/llm_composer/models/open_ai.ex
+++ b/lib/llm_composer/models/open_ai.ex
@@ -112,6 +112,10 @@ defmodule LlmComposer.Models.OpenAI do
     {:error, resp}
   end
 
+  defp handle_response({:error, reason}) do
+    {:error, reason}
+  end
+
   defp cleanup_body(body) do
     body
     |> Enum.reject(fn

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LlmComposer.MixProject do
   def project do
     [
       app: :llm_composer,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
We were not handling `{:error, :timeout}` https://doofindercom.sentry.io/issues/5984937217