### PR TITLE
Adjust @spec for `run` function

### DIFF
--- a/lib/llm_composer/providers_runner.ex
+++ b/lib/llm_composer/providers_runner.ex
@@ -15,7 +15,7 @@ defmodule LlmComposer.ProvidersRunner do
   @doc """
   Runs provider execution with fallback support for multiple providers.
   """
-  @spec run(messages(), Settings.t(), Message.t()) :: {:ok, any()} | {:error, atom()}
+  @spec run(messages(), Settings.t(), Message.t()) :: {:ok, any()} | {:error, term()}
   def run(messages, %Settings{providers: [{provider, provider_opts}]} = settings, system_msg) do
     # only one provider, directly run it.
     provider_opts = get_provider_opts(provider_opts, settings)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LlmComposer.MixProject do
   def project do
     [
       app: :llm_composer,
-      version: "0.16.1",
+      version: "0.16.2",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Looking at the `behavior` definition, `run` is actually specified to return `{:error, term()}`. However, in `providers_runner()`, the result of `run` is returned while the function spec declared `{:error, atom()}`. That is not correct, not because of the behavior itself, but because providers like `Bedrock`, as they are currently implemented, can in fact return something other than an `atom()` as the second element of the tuple. This causes problems with `dialyzer` when pattern matching on the result of a `run_completion()` for values where the second element of the error tuple is not an atom.