### PR TITLE
Add Bedrock streaming, tool calls anbd structured output support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,46 +45,72 @@ lib
 │   │   └── pricing.ex
 │   ├── cost_info.ex
 │   ├── errors.ex
-│   ├── function.ex
 │   ├── function_call.ex
+│   ├── function_call_extractors.ex
+│   ├── function_call_helpers.ex
+│   ├── function.ex
+│   ├── function_executor.ex
 │   ├── helpers.ex
 │   ├── http_client.ex
 │   ├── llm_response.ex
 │   ├── message.ex
 │   ├── provider.ex
-│   ├── provider_router
-│   │   └── simple.ex
-│   ├── provider_router.ex
-│   ├── providers
+│   ├── provider_response
 │   │   ├── bedrock.ex
 │   │   ├── google.ex
 │   │   ├── ollama.ex
 │   │   ├── open_ai.ex
+│   │   ├── open_ai_responses.ex
+│   │   ├── open_router.ex
+│   │   ├── parser
+│   │   │   ├── bedrock.ex
+│   │   │   ├── google.ex
+│   │   │   ├── ollama.ex
+│   │   │   └── open_ai.ex
+│   │   └── struct.ex
+│   ├── provider_response.ex
+│   ├── provider_router
+│   │   └── simple.ex
+│   ├── provider_router.ex
+│   ├── providers
+│   │   ├── bedrock
+│   │   │   ├── http_client.ex
+│   │   │   └── stream_operation.ex
+│   │   ├── bedrock.ex
+│   │   ├── google.ex
+│   │   ├── ollama.ex
+│   │   ├── open_ai.ex
+│   │   ├── open_ai_responses
+│   │   │   └── reasoning.ex
+│   │   ├── open_ai_responses.ex
 │   │   ├── open_router.ex
 │   │   └── utils.ex
 │   ├── providers_runner.ex
-│   └── settings.ex
+│   ├── provider_stream_chunk
+│   │   ├── bedrock.ex
+│   │   ├── google.ex
+│   │   ├── ollama.ex
+│   │   ├── open_ai.ex
+│   │   ├── open_ai_responses.ex
+│   │   ├── open_router.ex
+│   │   ├── parser
+│   │   │   ├── bedrock.ex
+│   │   │   ├── google.ex
+│   │   │   ├── ollama.ex
+│   │   │   ├── open_ai.ex
+│   │   │   └── open_ai_responses.ex
+│   │   └── struct.ex
+│   ├── provider_stream_chunk.ex
+│   ├── settings.ex
+│   └── stream_chunk.ex
 └── llm_composer.ex
 test
 ├── llm_composer
-│   ├── cost
-│   │   ├── cost_assembler_test.exs
-│   │   ├── cost_info_test.exs
-│   │   ├── pricing_test.exs
-│   │   └── providers
-│   │       ├── google_test.exs
-│   │       ├── ollama_test.exs
-│   │       ├── open_ai_test.exs
-│   │       ├── open_router_test.exs
-│   │       └── utils_test.exs
-│   ├── function_calls_auto_execution_test.exs
+│   ├── cost/                  # cost_assembler, cost_info, pricing tests
+│   ├── providers/             # per-provider tests (bedrock, google, ollama, open_ai, open_router, utils)
+│   ├── http_client_test.exs
 │   ├── provider_router_simple_test.exs
-│   └── providers
-│       ├── google_test.exs
-│       ├── ollama_test.exs
-│       ├── open_ai_test.exs
-│       ├── open_router_test.exs
-│       └── utils_test.exs
+│   └── stream_chunk_test.exs
 ├── llm_composer_test.exs
 └── test_helper.exs
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-04-07
+
 ### Added
 - Added automatic cost tracking for the Bedrock provider: token usage and costs are now populated in `LlmResponse.cost_info` when `track_costs: true` is set. Pricing is fetched automatically from models.dev (`amazon-bedrock` dataset) with a three-step lookup: exact model name, region prefix stripped (`eu.`, `us.`, `ap.`, `global.`), then date suffix stripped. Explicit `input_price_per_million` / `output_price_per_million` opts are also supported.
 - Added streaming support for Amazon Bedrock via the `ConverseStream` API, with AWS Event Stream binary frame parsing.
@@ -281,7 +283,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Initial release with support for basic message handling, interaction with OpenAI and Ollama models, and a foundational structure for model settings and function execution.
 
 ---
-[Unreleased]: https://github.com/doofinder/llm_composer/compare/0.18.2...HEAD
+[Unreleased]: https://github.com/doofinder/llm_composer/compare/0.19.0...HEAD
+[0.19.0]: https://github.com/doofinder/llm_composer/compare/0.18.2...0.19.0
 [0.18.2]: https://github.com/doofinder/llm_composer/compare/0.18.1...0.18.2
 [0.18.1]: https://github.com/doofinder/llm_composer/compare/0.18.0...0.18.1
 [0.18.0]: https://github.com/doofinder/llm_composer/compare/0.17.1...0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added tool calls (function calling) support for Bedrock: request serialization with `toolConfig`, `toolUse` extraction from responses, `toolResult` formatting, and automatic merging of consecutive tool-result user turns as required by the Bedrock API.
 - Added `LlmComposer.Providers.Bedrock.HttpClient` — a custom ExAws HTTP client that uses Mint by default for both streaming and regular requests, with optional Finch support when `config :llm_composer, :tesla_adapter, {Tesla.Adapter.Finch, name: MyFinch}` is set.
 - Added `ProviderStreamChunk.Parser.Bedrock` to normalize Bedrock stream events (`text_delta`, `done`, `usage`) into the shared `StreamChunk` format.
+- Added `response_schema` structured output support for Bedrock: pass a JSON schema map and it is automatically mapped to the Bedrock Converse API `outputConfig` format (schema is JSON-encoded as required by the API).
 
 ### Changed
 - Bedrock now auto-injects `LlmComposer.Providers.Bedrock.HttpClient` as the ExAws HTTP client when `config :ex_aws, :http_client` is not explicitly set, removing the previous requirement to configure Hackney or Finch manually.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- Added streaming support for Amazon Bedrock via the `ConverseStream` API, with AWS Event Stream binary frame parsing.
+- Added tool calls (function calling) support for Bedrock: request serialization with `toolConfig`, `toolUse` extraction from responses, `toolResult` formatting, and automatic merging of consecutive tool-result user turns as required by the Bedrock API.
+- Added `LlmComposer.Providers.Bedrock.HttpClient` — a custom ExAws HTTP client that uses Mint by default for both streaming and regular requests, with optional Finch support when `config :llm_composer, :tesla_adapter, {Tesla.Adapter.Finch, name: MyFinch}` is set.
+- Added `ProviderStreamChunk.Parser.Bedrock` to normalize Bedrock stream events (`text_delta`, `done`, `usage`) into the shared `StreamChunk` format.
+
+### Changed
+- Bedrock now auto-injects `LlmComposer.Providers.Bedrock.HttpClient` as the ExAws HTTP client when `config :ex_aws, :http_client` is not explicitly set, removing the previous requirement to configure Hackney or Finch manually.
+
 ## [0.18.2] - 2026-04-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- Added automatic cost tracking for the Bedrock provider: token usage and costs are now populated in `LlmResponse.cost_info` when `track_costs: true` is set. Pricing is fetched automatically from models.dev (`amazon-bedrock` dataset) with a three-step lookup: exact model name, region prefix stripped (`eu.`, `us.`, `ap.`, `global.`), then date suffix stripped. Explicit `input_price_per_million` / `output_price_per_million` opts are also supported.
 - Added streaming support for Amazon Bedrock via the `ConverseStream` API, with AWS Event Stream binary frame parsing.
 - Added tool calls (function calling) support for Bedrock: request serialization with `toolConfig`, `toolUse` extraction from responses, `toolResult` formatting, and automatic merging of consecutive tool-result user turns as required by the Bedrock API.
 - Added `LlmComposer.Providers.Bedrock.HttpClient` — a custom ExAws HTTP client that uses Mint by default for both streaming and regular requests, with optional Finch support when `config :llm_composer, :tesla_adapter, {Tesla.Adapter.Finch, name: MyFinch}` is set.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The following table shows which features are supported by each provider:
 | Streaming | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Function Calls | ✅ | ✅ | ⚠️¹ | ✅ | ✅ |
 | Structured Outputs | ✅ | ✅ | ⚠️¹ | ✅ | ✅ |
-| Cost Tracking | ✅ | ✅ | ❌ | ❌ | ✅ |
+| Cost Tracking | ✅ | ✅ | ❌ | ✅ | ✅ |
 | Fallback Models | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Provider Routing | ❌ | ✅ | ❌ | ❌ | ❌ |
 
@@ -398,8 +398,6 @@ end)
 ### Using AWS Bedrock
 
 LlmComposer also integrates with [Bedrock](https://aws.amazon.com/es/bedrock/) via its Converse API. This allows you to use Bedrock as a provider with any of its supported models.
-
-Currently, function execution is **not supported** with Bedrock.
 
 To integrate with Bedrock, LlmComposer uses the [`ex_aws`](https://hexdocs.pm/ex_aws/readme.html#aws-key-configuration) to perform its requests. So, if you plan to use Bedrock, make sure that you have configured `ex_aws` as per the official documentation of the library.
 
@@ -993,7 +991,7 @@ To use cost tracking, you need:
 
 #### Automatic Cost Tracking
 
-**OpenAI** and **Google** support automatic cost tracking via the models.dev dataset. When you enable `track_costs: true` and do not supply explicit prices, LlmComposer will fetch pricing from models.dev and cache it (ETS). Start the cache before using automatic pricing.
+**OpenAI**, **Google**, and **Bedrock** support automatic cost tracking via the models.dev dataset. When you enable `track_costs: true` and do not supply explicit prices, LlmComposer will fetch pricing from models.dev and cache it (ETS). Start the cache before using automatic pricing.
 
 ```elixir
 # OpenAI automatic pricing example

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ The following table shows which features are supported by each provider:
 | Feature | OpenAI | OpenRouter | Ollama | Bedrock | Google |
 |---------|--------|------------|--------|---------|--------|
 | Basic Chat | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Streaming | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Function Calls | ✅ | ✅ | ⚠️¹ | ❌ | ✅ |
+| Streaming | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Function Calls | ✅ | ✅ | ⚠️¹ | ✅ | ✅ |
 | Structured Outputs | ✅ | ✅ | ⚠️¹ | ❌ | ✅ |
 | Cost Tracking | ✅ | ✅ | ❌ | ❌ | ✅ |
 | Fallback Models | ❌ | ✅ | ❌ | ❌ | ❌ |
@@ -92,7 +92,7 @@ The following table shows which features are supported by each provider:
 - **OpenRouter** offers the most comprehensive feature set, including unique capabilities like fallback models and provider routing
 - **Google** provides full feature support including function calls, structured outputs, and streaming with Gemini models
 - **OpenAI Responses API** is available via `LlmComposer.Providers.OpenAIResponses` with manual function calls, structured outputs, and streaming support (see dedicated section below)
-- **Bedrock** support is provided via AWS ExAws integration and requires proper AWS configuration
+- **Bedrock** support is provided via AWS ExAws integration and requires proper AWS configuration; streaming uses Mint by default (no extra dependencies required)
 - **Ollama** requires an ollama server instance to be running
 - **Function Calls** - LlmComposer exposes function call handling via `FunctionExecutor.execute/2` for explicit execution; supported by OpenAI, OpenRouter, and Google
 - **Streaming** is **not** compatible with Tesla **retries**.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The following table shows which features are supported by each provider:
 | Basic Chat | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Streaming | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Function Calls | ✅ | ✅ | ⚠️¹ | ✅ | ✅ |
-| Structured Outputs | ✅ | ✅ | ⚠️¹ | ❌ | ✅ |
+| Structured Outputs | ✅ | ✅ | ⚠️¹ | ✅ | ✅ |
 | Cost Tracking | ✅ | ✅ | ❌ | ❌ | ✅ |
 | Fallback Models | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Provider Routing | ❌ | ✅ | ❌ | ❌ | ❌ |

--- a/lib/llm_composer.ex
+++ b/lib/llm_composer.ex
@@ -196,6 +196,9 @@ defmodule LlmComposer do
   defp provider_stream_struct(:ollama, payload, opts),
     do: ProviderStreamChunk.Ollama.new(payload, opts)
 
+  defp provider_stream_struct(:bedrock, payload, opts),
+    do: ProviderStreamChunk.Bedrock.new(payload, opts)
+
   defp provider_stream_struct(provider, _payload, _opts) do
     {:error, %{reason: :unsupported_stream_provider, provider: provider}}
   end

--- a/lib/llm_composer/cost/cost_assembler.ex
+++ b/lib/llm_composer/cost/cost_assembler.ex
@@ -80,6 +80,13 @@ defmodule LlmComposer.Cost.CostAssembler do
     {input, output, nil}
   end
 
+  def extract_tokens(:bedrock, raw_response) do
+    usage = Map.get(raw_response, "usage", %{})
+    input = Map.get(usage, "inputTokens", 0)
+    output = Map.get(usage, "outputTokens", 0)
+    {input, output, nil}
+  end
+
   def extract_tokens(_provider, _raw_response) do
     {0, 0, nil}
   end
@@ -91,6 +98,10 @@ defmodule LlmComposer.Cost.CostAssembler do
   end
 
   defp get_model(:google, _raw_response, opts) do
+    Keyword.get(opts, :model)
+  end
+
+  defp get_model(:bedrock, _raw_response, opts) do
     Keyword.get(opts, :model)
   end
 

--- a/lib/llm_composer/cost/fetchers/models_dev.ex
+++ b/lib/llm_composer/cost/fetchers/models_dev.ex
@@ -1,20 +1,27 @@
 defmodule LlmComposer.Cost.Fetchers.ModelsDev do
   @moduledoc """
-  models.dev-specific pricing fetcher for OpenAI and Google providers.
+  models.dev-specific pricing fetcher for OpenAI, Google, and Bedrock providers.
 
-  Fetches pricing information from the models.dev API dataset for OpenAI and Google
-  models. Uses 24-hour caching to minimize API calls and improve performance.
+  Fetches pricing information from the models.dev API dataset for OpenAI, Google,
+  and Amazon Bedrock models. Uses 24-hour caching to minimize API calls and improve
+  performance.
 
   ## Supported Providers
 
   - `:open_ai` - OpenAI models (GPT series)
   - `:open_ai_responses` - OpenAI Responses API models (same pricing family as `:open_ai`)
   - `:google` - Google Gemini models
+  - `:bedrock` - Amazon Bedrock models (indexed under `"amazon-bedrock"`)
 
   ## Implementation Notes
 
   models.dev provides a single consolidated dataset (api.json) containing pricing
   for multiple providers. The entire dataset is cached to avoid repeated downloads.
+
+  For Bedrock, model lookup uses the following fallback chain:
+  1. Exact model name (some region-prefixed variants are indexed, e.g. `"eu.anthropic.claude-sonnet-4-6"`)
+  2. Region prefix stripped (e.g. `"eu.amazon.nova-lite-v1:0"` → `"amazon.nova-lite-v1:0"`)
+  3. Date suffix stripped (e.g. `"amazon.nova-lite-v1:0-2026-01-01"` → `"amazon.nova-lite-v1:0"`)
   """
 
   alias LlmComposer.HttpClient
@@ -27,7 +34,8 @@ defmodule LlmComposer.Cost.Fetchers.ModelsDev do
   @default_cache_ttl_in_hours 24
 
   @spec fetch_pricing(atom(), String.t()) :: map() | nil
-  def fetch_pricing(provider, model) when provider in [:open_ai, :open_ai_responses, :google] do
+  def fetch_pricing(provider, model)
+      when provider in [:open_ai, :open_ai_responses, :google, :bedrock] do
     case fetch_with_cache() do
       {:ok, data} -> extract_pricing_from_data(data, provider, model)
       :error -> nil
@@ -125,14 +133,33 @@ defmodule LlmComposer.Cost.Fetchers.ModelsDev do
 
   defp get_cost(data, provider_key, model) do
     case get_in(data, [provider_key, "models", model, "cost"]) do
-      nil -> fallback_cost(data, provider_key, model)
+      nil -> fallback_strip_region(data, provider_key, model)
       cost -> cost
+    end
+  end
+
+  # Some Bedrock models have region prefixes (eu., us., ap., global.) that are not
+  # indexed in models.dev. Strip the prefix and retry before falling back further.
+  defp fallback_strip_region(data, provider_key, model) do
+    case strip_region_prefix(model) do
+      ^model ->
+        fallback_strip_date(data, provider_key, model)
+
+      stripped_model ->
+        Logger.debug(
+          "Retrying models.dev pricing lookup for #{provider_key}/#{model} without region prefix (#{stripped_model})"
+        )
+
+        case get_in(data, [provider_key, "models", stripped_model, "cost"]) do
+          nil -> fallback_strip_date(data, provider_key, stripped_model)
+          cost -> cost
+        end
     end
   end
 
   # APIs like OpenAI return snapshot model names with a date suffix (e.g. "gpt-5.4-mini-2026-03-17"),
   # but models.dev only indexes the base name. Strip the suffix and retry.
-  defp fallback_cost(data, provider_key, model) do
+  defp fallback_strip_date(data, provider_key, model) do
     case strip_snapshot_date_suffix(model) do
       ^model ->
         nil
@@ -146,6 +173,12 @@ defmodule LlmComposer.Cost.Fetchers.ModelsDev do
     end
   end
 
+  @region_prefix_regex ~r/^(?:eu|us|ap|global)\./
+
+  defp strip_region_prefix(model) when is_binary(model) do
+    Regex.replace(@region_prefix_regex, model, "")
+  end
+
   defp strip_snapshot_date_suffix(model) when is_binary(model) do
     Regex.replace(~r/-\d{4}-\d{2}-\d{2}$/, model, "")
   end
@@ -153,4 +186,5 @@ defmodule LlmComposer.Cost.Fetchers.ModelsDev do
   defp provider_key(:open_ai), do: "openai"
   defp provider_key(:open_ai_responses), do: "openai"
   defp provider_key(:google), do: "google"
+  defp provider_key(:bedrock), do: "amazon-bedrock"
 end

--- a/lib/llm_composer/cost/fetchers/models_dev.ex
+++ b/lib/llm_composer/cost/fetchers/models_dev.ex
@@ -32,6 +32,7 @@ defmodule LlmComposer.Cost.Fetchers.ModelsDev do
   @models_dev_url "https://models.dev/"
   @cache_key "models_dev_api"
   @default_cache_ttl_in_hours 24
+  @region_prefix_regex ~r/^(?:eu|us|ap|global)\./
 
   @spec fetch_pricing(atom(), String.t()) :: map() | nil
   def fetch_pricing(provider, model)
@@ -172,8 +173,6 @@ defmodule LlmComposer.Cost.Fetchers.ModelsDev do
         get_in(data, [provider_key, "models", fallback_model, "cost"])
     end
   end
-
-  @region_prefix_regex ~r/^(?:eu|us|ap|global)\./
 
   defp strip_region_prefix(model) when is_binary(model) do
     Regex.replace(@region_prefix_regex, model, "")

--- a/lib/llm_composer/cost/pricing.ex
+++ b/lib/llm_composer/cost/pricing.ex
@@ -26,7 +26,7 @@ defmodule LlmComposer.Cost.Pricing do
         :open_router ->
           fetch_openrouter_pricing(opts)
 
-        provider when provider in [:open_ai, :open_ai_responses, :google] ->
+        provider when provider in [:open_ai, :open_ai_responses, :google, :bedrock] ->
           fetch_models_dev_pricing(provider, opts)
 
         _ ->
@@ -65,7 +65,7 @@ defmodule LlmComposer.Cost.Pricing do
   end
 
   defp fetch_models_dev_pricing(provider, opts)
-       when provider in [:open_ai, :open_ai_responses, :google] do
+       when provider in [:open_ai, :open_ai_responses, :google, :bedrock] do
     model = Keyword.get(opts, :model)
 
     if is_nil(model) do

--- a/lib/llm_composer/function_call_extractors.ex
+++ b/lib/llm_composer/function_call_extractors.ex
@@ -49,4 +49,28 @@ defmodule LlmComposer.FunctionCallExtractors do
   end
 
   def from_google_parts(_), do: nil
+
+  @spec from_bedrock_content(list()) :: [FunctionCall.t()] | nil
+  def from_bedrock_content(content) when is_list(content) do
+    calls =
+      content
+      |> Enum.filter(&Map.has_key?(&1, "toolUse"))
+      |> Enum.map(fn %{"toolUse" => tool_use} ->
+        %FunctionCall{
+          id: tool_use["toolUseId"],
+          name: tool_use["name"],
+          arguments: Helpers.json_engine().encode!(tool_use["input"] || %{}),
+          type: "tool_use",
+          metadata: %{},
+          result: nil
+        }
+      end)
+
+    case calls do
+      [] -> nil
+      list -> list
+    end
+  end
+
+  def from_bedrock_content(_), do: nil
 end

--- a/lib/llm_composer/provider_response/parser/bedrock.ex
+++ b/lib/llm_composer/provider_response/parser/bedrock.ex
@@ -8,6 +8,16 @@ defmodule LlmComposer.ProviderResponse.Parser.Bedrock do
           {:ok, LlmResponse.t()} | {:error, term()}
   def parse({:error, resp}, _provider, _opts), do: {:error, resp}
 
+  def parse({:ok, %{stream: stream}}, :bedrock, _opts) do
+    {:ok,
+     LlmResponse.new(%{
+       provider: :bedrock,
+       status: :ok,
+       stream: stream,
+       raw: stream
+     })}
+  end
+
   def parse({:ok, %{response: response} = provider_response}, :bedrock, _opts) do
     [%{"text" => message_content}] = response["output"]["message"]["content"]
     role = String.to_existing_atom(response["output"]["message"]["role"])

--- a/lib/llm_composer/provider_response/parser/bedrock.ex
+++ b/lib/llm_composer/provider_response/parser/bedrock.ex
@@ -1,6 +1,7 @@
 defmodule LlmComposer.ProviderResponse.Parser.Bedrock do
   @moduledoc false
 
+  alias LlmComposer.Cost.CostAssembler
   alias LlmComposer.FunctionCallExtractors
   alias LlmComposer.LlmResponse
   alias LlmComposer.Message
@@ -19,7 +20,7 @@ defmodule LlmComposer.ProviderResponse.Parser.Bedrock do
      })}
   end
 
-  def parse({:ok, %{response: response} = provider_response}, :bedrock, _opts) do
+  def parse({:ok, %{response: response}}, :bedrock, opts) do
     content = response["output"]["message"]["content"]
     role = String.to_existing_atom(response["output"]["message"]["role"])
 
@@ -31,6 +32,8 @@ defmodule LlmComposer.ProviderResponse.Parser.Bedrock do
       | function_calls: function_calls
     }
 
+    cost_info = CostAssembler.get_cost_info(:bedrock, response, opts)
+
     {:ok,
      LlmResponse.new(%{
        provider: :bedrock,
@@ -38,7 +41,7 @@ defmodule LlmComposer.ProviderResponse.Parser.Bedrock do
        main_response: message,
        input_tokens: response["usage"]["inputTokens"],
        output_tokens: response["usage"]["outputTokens"],
-       cost_info: Map.get(provider_response, :cost_info),
+       cost_info: cost_info,
        raw: response
      })}
   end

--- a/lib/llm_composer/provider_response/parser/bedrock.ex
+++ b/lib/llm_composer/provider_response/parser/bedrock.ex
@@ -1,6 +1,7 @@
 defmodule LlmComposer.ProviderResponse.Parser.Bedrock do
   @moduledoc false
 
+  alias LlmComposer.FunctionCallExtractors
   alias LlmComposer.LlmResponse
   alias LlmComposer.Message
 
@@ -19,15 +20,22 @@ defmodule LlmComposer.ProviderResponse.Parser.Bedrock do
   end
 
   def parse({:ok, %{response: response} = provider_response}, :bedrock, _opts) do
-    [%{"text" => message_content}] = response["output"]["message"]["content"]
+    content = response["output"]["message"]["content"]
     role = String.to_existing_atom(response["output"]["message"]["role"])
+
+    message_content = extract_text(content)
+    function_calls = FunctionCallExtractors.from_bedrock_content(content)
+
+    message = %{
+      Message.new(role, message_content, %{original: response["output"]["message"]})
+      | function_calls: function_calls
+    }
 
     {:ok,
      LlmResponse.new(%{
        provider: :bedrock,
        status: :ok,
-       main_response:
-         Message.new(role, message_content, %{original: response["output"]["message"]}),
+       main_response: message,
        input_tokens: response["usage"]["inputTokens"],
        output_tokens: response["usage"]["outputTokens"],
        cost_info: Map.get(provider_response, :cost_info),
@@ -42,5 +50,15 @@ defmodule LlmComposer.ProviderResponse.Parser.Bedrock do
        provider: provider,
        response: result
      }}
+  end
+
+  @spec extract_text(list()) :: String.t() | nil
+  defp extract_text(content) when is_list(content) do
+    joined =
+      content
+      |> Enum.filter(&Map.has_key?(&1, "text"))
+      |> Enum.map_join("", & &1["text"])
+
+    if joined == "", do: nil, else: joined
   end
 end

--- a/lib/llm_composer/provider_stream_chunk/bedrock.ex
+++ b/lib/llm_composer/provider_stream_chunk/bedrock.ex
@@ -1,0 +1,7 @@
+defmodule LlmComposer.ProviderStreamChunk.Bedrock do
+  @moduledoc false
+
+  use LlmComposer.ProviderStreamChunk.Struct,
+    parser: LlmComposer.ProviderStreamChunk.Parser.Bedrock,
+    provider: :bedrock
+end

--- a/lib/llm_composer/provider_stream_chunk/parser/bedrock.ex
+++ b/lib/llm_composer/provider_stream_chunk/parser/bedrock.ex
@@ -1,0 +1,46 @@
+defmodule LlmComposer.ProviderStreamChunk.Parser.Bedrock do
+  @moduledoc false
+
+  alias LlmComposer.StreamChunk
+
+  @spec parse(map(), atom(), keyword()) :: {:ok, StreamChunk.t()} | :skip
+  def parse(%{"delta" => %{"text" => text}} = raw, :bedrock, _opts) do
+    {:ok,
+     %StreamChunk{
+       provider: :bedrock,
+       type: :text_delta,
+       text: text,
+       metadata: %{},
+       raw: raw
+     }}
+  end
+
+  def parse(%{"stopReason" => reason} = raw, :bedrock, _opts) do
+    {:ok,
+     %StreamChunk{
+       provider: :bedrock,
+       type: :done,
+       metadata: %{finish_reason: reason},
+       raw: raw
+     }}
+  end
+
+  def parse(%{"usage" => usage} = raw, :bedrock, _opts) do
+    {:ok,
+     %StreamChunk{
+       provider: :bedrock,
+       type: :usage,
+       usage: %{
+         input_tokens: usage["inputTokens"],
+         output_tokens: usage["outputTokens"],
+         total_tokens: usage["totalTokens"],
+         cached_tokens: nil,
+         reasoning_tokens: nil
+       },
+       metadata: %{},
+       raw: raw
+     }}
+  end
+
+  def parse(_raw, :bedrock, _opts), do: :skip
+end

--- a/lib/llm_composer/provider_stream_chunk/parser/bedrock.ex
+++ b/lib/llm_composer/provider_stream_chunk/parser/bedrock.ex
@@ -15,6 +15,32 @@ defmodule LlmComposer.ProviderStreamChunk.Parser.Bedrock do
      }}
   end
 
+  def parse(
+        %{"start" => %{"toolUse" => %{"toolUseId" => id, "name" => name}}} = raw,
+        :bedrock,
+        _opts
+      ) do
+    {:ok,
+     %StreamChunk{
+       provider: :bedrock,
+       type: :tool_call_delta,
+       tool_calls: [%{"toolUseId" => id, "name" => name, "inputJson" => ""}],
+       metadata: %{},
+       raw: raw
+     }}
+  end
+
+  def parse(%{"delta" => %{"toolUse" => %{"input" => input}}} = raw, :bedrock, _opts) do
+    {:ok,
+     %StreamChunk{
+       provider: :bedrock,
+       type: :tool_call_delta,
+       tool_calls: [%{"inputJson" => input}],
+       metadata: %{},
+       raw: raw
+     }}
+  end
+
   def parse(%{"stopReason" => reason} = raw, :bedrock, _opts) do
     {:ok,
      %StreamChunk{

--- a/lib/llm_composer/providers/bedrock.ex
+++ b/lib/llm_composer/providers/bedrock.ex
@@ -91,7 +91,7 @@ if Code.ensure_loaded?(ExAws) do
 
     @spec send_request(map(), String.t(), boolean()) :: {:ok, term()} | {:error, term()}
     defp send_request(payload, model, true) do
-      opts = Keyword.put(ex_aws_opts(), :http_opts, [stream: true])
+      opts = Keyword.put(ex_aws_opts(), :http_opts, stream: true)
 
       payload
       |> StreamOperation.new(model)

--- a/lib/llm_composer/providers/bedrock.ex
+++ b/lib/llm_composer/providers/bedrock.ex
@@ -12,6 +12,7 @@ if Code.ensure_loaded?(ExAws) do
 
     alias LlmComposer.Message
     alias LlmComposer.ProviderResponse
+    alias LlmComposer.Providers.Bedrock.StreamOperation
     alias LlmComposer.Providers.Utils
 
     @impl LlmComposer.Provider
@@ -20,15 +21,17 @@ if Code.ensure_loaded?(ExAws) do
     @impl LlmComposer.Provider
     @doc """
     Reference: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
+    Reference (stream): https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseStream.html
     """
     def run(messages, system_message, opts) do
       model = Keyword.get(opts, :model)
+      stream = Keyword.get(opts, :stream_response, false)
 
       if model do
         messages
         |> build_request(system_message, opts)
-        |> send_request(model)
-        |> handle_response()
+        |> send_request(model, stream)
+        |> handle_response(stream)
         |> wrap_response(opts)
       else
         {:error, :model_not_provided}
@@ -49,8 +52,14 @@ if Code.ensure_loaded?(ExAws) do
       |> Utils.cleanup_body()
     end
 
-    @spec send_request(map(), String.t()) :: {:ok, map()} | {:error, term()}
-    defp send_request(payload, model) do
+    @spec send_request(map(), String.t(), boolean()) :: {:ok, term()} | {:error, term()}
+    defp send_request(payload, model, true) do
+      payload
+      |> StreamOperation.new(model)
+      |> ExAws.request(service_override: :bedrock, http_opts: [stream: true])
+    end
+
+    defp send_request(payload, model, false) do
       operation = %ExAws.Operation.JSON{
         data: payload,
         headers: [{"Content-Type", "application/json"}],
@@ -59,8 +68,7 @@ if Code.ensure_loaded?(ExAws) do
         service: :"bedrock-runtime"
       }
 
-      config = [service_override: :bedrock]
-      ExAws.request(operation, config)
+      ExAws.request(operation, service_override: :bedrock)
     end
 
     @spec format_message(Message.t()) :: map()
@@ -76,8 +84,21 @@ if Code.ensure_loaded?(ExAws) do
       %{"role" => Atom.to_string(role), "content" => content}
     end
 
-    @spec handle_response({:ok, map()} | {:error, map()}) :: {:ok, map()} | {:error, term}
-    defp handle_response({:ok, %{"output" => %{"message" => _message}} = response}) do
+    @spec handle_response({:ok, term()} | {:error, term()}, boolean()) ::
+            {:ok, map()} | {:error, term()}
+    defp handle_response({:ok, chunk_stream}, true) do
+      # Lazily parse AWS Event Stream frames from the binary chunk stream.
+      # Frame layout: [4B total_len][4B headers_len][4B prelude_crc][headers...][payload...][4B msg_crc]
+      # Each extracted payload is a JSON-encoded binary (one per event).
+      event_stream =
+        Stream.transform(chunk_stream, <<>>, fn chunk, buffer ->
+          extract_event_frames(buffer <> chunk, [])
+        end)
+
+      {:ok, %{stream: event_stream}}
+    end
+
+    defp handle_response({:ok, %{"output" => %{"message" => _}} = response}, false) do
       {:ok,
        %{
          response: response,
@@ -86,7 +107,7 @@ if Code.ensure_loaded?(ExAws) do
        }}
     end
 
-    defp handle_response({:error, resp}) do
+    defp handle_response({:error, resp}, _stream) do
       {:error, resp}
     end
 
@@ -95,5 +116,28 @@ if Code.ensure_loaded?(ExAws) do
       |> ProviderResponse.Bedrock.new(opts)
       |> ProviderResponse.to_llm_response(opts)
     end
+
+    # Extracts complete AWS Event Stream frames from a binary buffer.
+    # Returns {payloads, remaining_buffer} for use with Stream.transform.
+    # Incomplete frames are kept in the buffer for the next chunk.
+    @spec extract_event_frames(binary(), [binary()]) :: {[binary()], binary()}
+    defp extract_event_frames(
+           <<total_len::32-big-unsigned, headers_len::32-big-unsigned, _prelude_crc::32,
+             rest::binary>> = buffer,
+           acc
+         ) do
+      payload_len = total_len - headers_len - 16
+
+      if byte_size(rest) >= headers_len + payload_len + 4 do
+        <<_headers::binary-size(headers_len), payload::binary-size(payload_len), _msg_crc::32,
+          remaining::binary>> = rest
+
+        extract_event_frames(remaining, [payload | acc])
+      else
+        {Enum.reverse(acc), buffer}
+      end
+    end
+
+    defp extract_event_frames(buffer, acc), do: {Enum.reverse(acc), buffer}
   end
 end

--- a/lib/llm_composer/providers/bedrock.ex
+++ b/lib/llm_composer/providers/bedrock.ex
@@ -41,13 +41,24 @@ if Code.ensure_loaded?(ExAws) do
 
     @spec build_request(list(Message.t()), Message.t(), keyword()) :: map()
     defp build_request(messages, system_message, opts) do
-      base_request = %{
-        "messages" =>
-          messages
-          |> Enum.map(&format_message/1)
-          |> merge_consecutive_tool_results(),
-        "system" => [format_message(system_message)]
-      }
+      tools =
+        opts
+        |> Keyword.get(:functions)
+        |> Utils.get_tools(name())
+
+      tool_config = if tools, do: %{"toolConfig" => %{"tools" => tools}}, else: %{}
+
+      base_request =
+        Map.merge(
+          %{
+            "messages" =>
+              messages
+              |> Enum.map(&format_message/1)
+              |> merge_consecutive_tool_results(),
+            "system" => [format_message(system_message)]
+          },
+          tool_config
+        )
 
       req_params = Keyword.get(opts, :request_params, %{})
 

--- a/lib/llm_composer/providers/bedrock.ex
+++ b/lib/llm_composer/providers/bedrock.ex
@@ -83,7 +83,18 @@ if Code.ensure_loaded?(ExAws) do
         service: :"bedrock-runtime"
       }
 
-      ExAws.request(operation, service_override: :bedrock)
+      ExAws.request(operation, ex_aws_opts())
+    end
+
+    @spec ex_aws_opts() :: keyword()
+    defp ex_aws_opts do
+      base = [service_override: :bedrock]
+
+      if Application.get_env(:ex_aws, :http_client) do
+        base
+      else
+        Keyword.put(base, :http_client, LlmComposer.Providers.Bedrock.HttpClient)
+      end
     end
 
     @spec format_message(Message.t()) :: map()

--- a/lib/llm_composer/providers/bedrock.ex
+++ b/lib/llm_composer/providers/bedrock.ex
@@ -64,7 +64,29 @@ if Code.ensure_loaded?(ExAws) do
 
       base_request
       |> Utils.merge_request_params(req_params)
+      |> maybe_structured_output(opts)
       |> Utils.cleanup_body()
+    end
+
+    @spec maybe_structured_output(map(), keyword()) :: map()
+    defp maybe_structured_output(base_request, opts) do
+      response_schema = Keyword.get(opts, :response_schema)
+
+      if is_map(response_schema) do
+        Map.put(base_request, "outputConfig", %{
+          "textFormat" => %{
+            "type" => "json_schema",
+            "structure" => %{
+              "jsonSchema" => %{
+                "name" => "response",
+                "schema" => Helpers.json_engine().encode!(response_schema)
+              }
+            }
+          }
+        })
+      else
+        base_request
+      end
     end
 
     @spec send_request(map(), String.t(), boolean()) :: {:ok, term()} | {:error, term()}

--- a/lib/llm_composer/providers/bedrock.ex
+++ b/lib/llm_composer/providers/bedrock.ex
@@ -91,9 +91,11 @@ if Code.ensure_loaded?(ExAws) do
 
     @spec send_request(map(), String.t(), boolean()) :: {:ok, term()} | {:error, term()}
     defp send_request(payload, model, true) do
+      opts = Keyword.put(ex_aws_opts(), :http_opts, [stream: true])
+
       payload
       |> StreamOperation.new(model)
-      |> ExAws.request(service_override: :bedrock, http_opts: [stream: true])
+      |> ExAws.request(opts)
     end
 
     defp send_request(payload, model, false) do
@@ -110,13 +112,7 @@ if Code.ensure_loaded?(ExAws) do
 
     @spec ex_aws_opts() :: keyword()
     defp ex_aws_opts do
-      base = [service_override: :bedrock]
-
-      if Application.get_env(:ex_aws, :http_client) do
-        base
-      else
-        Keyword.put(base, :http_client, LlmComposer.Providers.Bedrock.HttpClient)
-      end
+      [service_override: :bedrock, http_client: LlmComposer.Providers.Bedrock.HttpClient]
     end
 
     @spec format_message(Message.t()) :: map()

--- a/lib/llm_composer/providers/bedrock.ex
+++ b/lib/llm_composer/providers/bedrock.ex
@@ -10,6 +10,7 @@ if Code.ensure_loaded?(ExAws) do
     """
     @behaviour LlmComposer.Provider
 
+    alias LlmComposer.Helpers
     alias LlmComposer.Message
     alias LlmComposer.ProviderResponse
     alias LlmComposer.Providers.Bedrock.StreamOperation
@@ -41,7 +42,10 @@ if Code.ensure_loaded?(ExAws) do
     @spec build_request(list(Message.t()), Message.t(), keyword()) :: map()
     defp build_request(messages, system_message, opts) do
       base_request = %{
-        "messages" => Enum.map(messages, &format_message/1),
+        "messages" =>
+          messages
+          |> Enum.map(&format_message/1)
+          |> merge_consecutive_tool_results(),
         "system" => [format_message(system_message)]
       }
 
@@ -76,12 +80,77 @@ if Code.ensure_loaded?(ExAws) do
       %{"text" => content}
     end
 
+    defp format_message(%Message{type: :tool_result, content: content, metadata: metadata}) do
+      %{
+        "role" => "user",
+        "content" => [
+          %{
+            "toolResult" => %{
+              "toolUseId" => metadata["tool_call_id"],
+              "content" => [%{"text" => to_string(content)}]
+            }
+          }
+        ]
+      }
+    end
+
+    defp format_message(%Message{type: :assistant, metadata: metadata} = msg) do
+      case get_in(metadata, [:original, "content"]) do
+        original_content when is_list(original_content) ->
+          %{"role" => "assistant", "content" => original_content}
+
+        _ ->
+          build_assistant_content(msg)
+      end
+    end
+
     defp format_message(%Message{type: role, content: content}) when is_binary(content) do
       %{"role" => Atom.to_string(role), "content" => [%{"text" => content}]}
     end
 
     defp format_message(%Message{type: role, content: content}) do
       %{"role" => Atom.to_string(role), "content" => content}
+    end
+
+    @spec build_assistant_content(Message.t()) :: map()
+    defp build_assistant_content(%Message{content: content, function_calls: nil})
+         when is_binary(content) do
+      %{"role" => "assistant", "content" => [%{"text" => content}]}
+    end
+
+    defp build_assistant_content(%Message{content: content, function_calls: function_calls})
+         when is_list(function_calls) do
+      text_parts = if content && content != "", do: [%{"text" => content}], else: []
+
+      tool_parts =
+        Enum.map(function_calls, fn call ->
+          arguments =
+            if is_binary(call.arguments) do
+              Helpers.json_engine().decode!(call.arguments)
+            else
+              call.arguments || %{}
+            end
+
+          %{"toolUse" => %{"toolUseId" => call.id, "name" => call.name, "input" => arguments}}
+        end)
+
+      %{"role" => "assistant", "content" => text_parts ++ tool_parts}
+    end
+
+    # Merges consecutive tool-result user messages into a single content block.
+    # Bedrock requires all toolResult blocks for one assistant turn to be in one user turn.
+    @spec merge_consecutive_tool_results([map()]) :: [map()]
+    defp merge_consecutive_tool_results(messages) do
+      messages
+      |> Enum.reduce([], fn
+        %{"role" => "user", "content" => [%{"toolResult" => _} | _] = parts},
+        [%{"role" => "user", "content" => [%{"toolResult" => _} | _] = prev_parts} | rest] ->
+          [%{"role" => "user", "content" => prev_parts ++ parts} | rest]
+
+        msg, acc ->
+          [msg | acc]
+      end)
+      |> Enum.reverse()
     end
 
     @spec handle_response({:ok, term()} | {:error, term()}, boolean()) ::

--- a/lib/llm_composer/providers/bedrock/http_client.ex
+++ b/lib/llm_composer/providers/bedrock/http_client.ex
@@ -226,11 +226,11 @@ if Code.ensure_loaded?(ExAws) do
             {:ok, conn, responses} ->
               acc =
                 Enum.reduce(responses, acc, fn
-                  {:status, ^ref, status}, a -> %{a | status: status}
-                  {:headers, ^ref, hs}, a -> %{a | headers: a.headers ++ hs}
-                  {:data, ^ref, chunk}, a -> %{a | body: a.body <> chunk}
-                  {:done, ^ref}, a -> Map.put(a, :done, true)
-                  _other, a -> a
+                  {:status, ^ref, status}, acc -> %{acc | status: status}
+                  {:headers, ^ref, hs}, acc -> %{acc | headers: acc.headers ++ hs}
+                  {:data, ^ref, chunk}, acc -> %{acc | body: acc.body <> chunk}
+                  {:done, ^ref}, acc -> Map.put(acc, :done, true)
+                  _other, acc -> acc
                 end)
 
               if Map.get(acc, :done) do

--- a/lib/llm_composer/providers/bedrock/http_client.ex
+++ b/lib/llm_composer/providers/bedrock/http_client.ex
@@ -1,0 +1,157 @@
+if Code.ensure_loaded?(ExAws) do
+  defmodule LlmComposer.Providers.Bedrock.HttpClient do
+    @moduledoc """
+    ExAws HTTP client for Bedrock that delegates to the configured Tesla Finch adapter.
+
+    When `stream: true` is present in `http_opts`, uses `Finch.stream/5` in a spawned
+    process, forwarding events as messages to the caller. Returns a lazy `Stream` as the
+    response body — required for the ConverseStream binary event-stream response.
+
+    For regular requests (or when streaming is not requested), uses `Finch.request/3`.
+
+    Reads the Finch process name from the `:llm_composer` `:tesla_adapter` config:
+
+        config :llm_composer, :tesla_adapter, {Tesla.Adapter.Finch, name: MyFinch}
+
+    If Finch is not configured, logs a warning and attempts a fallback via
+    `ExAws.Request.Hackney` when available.
+    """
+
+    @behaviour ExAws.Request.HttpClient
+
+    alias ExAws.Request.Hackney
+
+    require Logger
+
+    @stream_timeout 30_000
+
+    @impl ExAws.Request.HttpClient
+    @spec request(
+            ExAws.Request.HttpClient.http_method(),
+            binary(),
+            binary(),
+            list(),
+            keyword()
+          ) ::
+            {:ok, %{status_code: pos_integer(), headers: list(), body: term()}}
+            | {:error, %{reason: term()}}
+    def request(method, url, body, headers, http_opts) do
+      stream = Keyword.get(http_opts, :stream, false)
+
+      case {stream, finch_name()} do
+        {true, {:ok, name}} ->
+          stream_request(method, url, body, headers, name)
+
+        {true, :error} ->
+          Logger.warning(
+            "[bedrock] Finch not configured in :llm_composer :tesla_adapter — " <>
+              "falling back to full response. " <>
+              "Add `config :llm_composer, :tesla_adapter, {Tesla.Adapter.Finch, name: MyFinch}` " <>
+              "for proper stream support."
+          )
+
+          full_request_fallback(method, url, body, headers)
+
+        {false, {:ok, name}} ->
+          regular_request(method, url, body, headers, name)
+
+        {false, :error} ->
+          full_request_fallback(method, url, body, headers)
+      end
+    end
+
+    @spec stream_request(atom(), binary(), binary(), list(), atom()) ::
+            {:ok, map()} | {:error, map()}
+    defp stream_request(method, url, body, headers, finch_name) do
+      req = Finch.build(method, url, headers, body)
+      caller = self()
+
+      Task.start(fn ->
+        Finch.stream(req, finch_name, nil, fn
+          {:status, status}, _acc ->
+            send(caller, {:bedrock_stream, {:status, status}})
+
+          {:headers, resp_headers}, _acc ->
+            send(caller, {:bedrock_stream, {:headers, resp_headers}})
+
+          {:data, chunk}, _acc ->
+            send(caller, {:bedrock_stream, {:data, chunk}})
+
+          _, _acc ->
+            nil
+        end)
+
+        send(caller, {:bedrock_stream, :done})
+      end)
+
+      case await_response_metadata() do
+        {:ok, {status, resp_headers}} ->
+          chunk_stream =
+            Stream.resource(
+              fn -> :ok end,
+              fn state ->
+                receive do
+                  {:bedrock_stream, {:data, chunk}} -> {[chunk], state}
+                  {:bedrock_stream, :done} -> {:halt, state}
+                after
+                  @stream_timeout -> {:halt, state}
+                end
+              end,
+              fn _state -> :ok end
+            )
+
+          {:ok, %{status_code: status, headers: resp_headers, body: chunk_stream}}
+
+        {:error, reason} ->
+          {:error, %{reason: reason}}
+      end
+    end
+
+    @spec await_response_metadata() :: {:ok, {pos_integer(), list()}} | {:error, term()}
+    defp await_response_metadata do
+      receive do
+        {:bedrock_stream, {:status, status}} ->
+          receive do
+            {:bedrock_stream, {:headers, resp_headers}} ->
+              {:ok, {status, resp_headers}}
+          after
+            @stream_timeout -> {:error, :timeout_waiting_for_headers}
+          end
+      after
+        @stream_timeout -> {:error, :timeout_waiting_for_status}
+      end
+    end
+
+    @spec regular_request(atom(), binary(), binary(), list(), atom()) ::
+            {:ok, map()} | {:error, map()}
+    defp regular_request(method, url, body, headers, finch_name) do
+      req = Finch.build(method, url, headers, body)
+
+      case Finch.request(req, finch_name) do
+        {:ok, %Finch.Response{status: status, headers: resp_headers, body: resp_body}} ->
+          {:ok, %{status_code: status, headers: resp_headers, body: resp_body}}
+
+        {:error, reason} ->
+          {:error, %{reason: reason}}
+      end
+    end
+
+    @spec full_request_fallback(atom(), binary(), binary(), list()) ::
+            {:ok, map()} | {:error, map()}
+    defp full_request_fallback(method, url, body, headers) do
+      if Code.ensure_loaded?(Hackney) do
+        Hackney.request(method, url, body, headers, [])
+      else
+        {:error, %{reason: :no_http_client_available}}
+      end
+    end
+
+    @spec finch_name() :: {:ok, atom()} | :error
+    defp finch_name do
+      case Application.get_env(:llm_composer, :tesla_adapter) do
+        {Tesla.Adapter.Finch, opts} when is_list(opts) -> Keyword.fetch(opts, :name)
+        _ -> :error
+      end
+    end
+  end
+end

--- a/lib/llm_composer/providers/bedrock/http_client.ex
+++ b/lib/llm_composer/providers/bedrock/http_client.ex
@@ -7,6 +7,9 @@ if Code.ensure_loaded?(ExAws) do
     process that forwards events as messages to the caller. Returns a lazy `Stream` as
     the response body — required for the ConverseStream binary event-stream response.
 
+    The spawned task is monitored with `Process.monitor/1` so any unexpected crash
+    surfaces immediately to the caller instead of waiting for the stream timeout.
+
     ## Default behaviour (Mint)
 
     Uses `Mint.HTTP` directly for both streaming and regular requests. No additional
@@ -72,27 +75,30 @@ if Code.ensure_loaded?(ExAws) do
       req = Finch.build(method, url, headers, body)
       caller = self()
 
-      Task.start(fn ->
-        Finch.stream(req, finch_name, nil, fn
-          {:status, status}, _acc ->
-            send(caller, {:bedrock_stream, {:status, status}})
+      {:ok, pid} =
+        Task.start(fn ->
+          Finch.stream(req, finch_name, nil, fn
+            {:status, status}, _acc ->
+              send(caller, {:bedrock_stream, {:status, status}})
 
-          {:headers, resp_headers}, _acc ->
-            send(caller, {:bedrock_stream, {:headers, resp_headers}})
+            {:headers, resp_headers}, _acc ->
+              send(caller, {:bedrock_stream, {:headers, resp_headers}})
 
-          {:data, chunk}, _acc ->
-            send(caller, {:bedrock_stream, {:data, chunk}})
+            {:data, chunk}, _acc ->
+              send(caller, {:bedrock_stream, {:data, chunk}})
 
-          _, _acc ->
-            nil
+            _, _acc ->
+              nil
+          end)
+
+          send(caller, {:bedrock_stream, :done})
         end)
 
-        send(caller, {:bedrock_stream, :done})
-      end)
+      ref = Process.monitor(pid)
 
-      case await_response_metadata() do
+      case await_response_metadata(ref) do
         {:ok, {status, resp_headers}} ->
-          {:ok, %{status_code: status, headers: resp_headers, body: build_chunk_stream()}}
+          {:ok, %{status_code: status, headers: resp_headers, body: build_chunk_stream(ref)}}
 
         {:error, reason} ->
           {:error, %{reason: reason}}
@@ -126,20 +132,22 @@ if Code.ensure_loaded?(ExAws) do
     defp stream_request_mint(method, url, body, headers) do
       caller = self()
 
-      Task.start(fn ->
-        case mint_connect_and_request(method, url, body, headers) do
-          {:ok, conn, ref} ->
-            stream_mint_loop(conn, ref, caller)
+      {:ok, pid} =
+        Task.start(fn ->
+          case mint_connect_and_request(method, url, body, headers) do
+            {:ok, conn, ref} ->
+              stream_mint_loop(conn, ref, caller)
 
-          {:error, reason} ->
-            send(caller, {:bedrock_stream, {:error, reason}})
-            send(caller, {:bedrock_stream, :done})
-        end
-      end)
+            {:error, reason} ->
+              send(caller, {:bedrock_stream, {:error, reason}})
+          end
+        end)
 
-      case await_response_metadata() do
+      ref = Process.monitor(pid)
+
+      case await_response_metadata(ref) do
         {:ok, {status, resp_headers}} ->
-          {:ok, %{status_code: status, headers: resp_headers, body: build_chunk_stream()}}
+          {:ok, %{status_code: status, headers: resp_headers, body: build_chunk_stream(ref)}}
 
         {:error, reason} ->
           {:error, %{reason: reason}}
@@ -160,7 +168,6 @@ if Code.ensure_loaded?(ExAws) do
 
             {:error, _conn, reason, _responses} ->
               send(caller, {:bedrock_stream, {:error, reason}})
-              send(caller, {:bedrock_stream, :done})
 
             :unknown ->
               stream_mint_loop(conn, ref, caller)
@@ -265,29 +272,44 @@ if Code.ensure_loaded?(ExAws) do
       end
     end
 
-    @spec await_response_metadata() :: {:ok, {pos_integer(), list()}} | {:error, term()}
-    defp await_response_metadata do
+    @spec await_response_metadata(reference()) ::
+            {:ok, {pos_integer(), list()}} | {:error, term()}
+    defp await_response_metadata(ref) do
       receive do
         {:bedrock_stream, {:status, status}} ->
           receive do
             {:bedrock_stream, {:headers, resp_headers}} ->
               {:ok, {status, resp_headers}}
+
+            {:bedrock_stream, {:error, reason}} ->
+              {:error, reason}
+
+            {:DOWN, ^ref, :process, _pid, reason} ->
+              {:error, {:task_crashed, reason}}
           after
             @stream_timeout -> {:error, :timeout_waiting_for_headers}
           end
+
+        {:bedrock_stream, {:error, reason}} ->
+          {:error, reason}
+
+        {:DOWN, ^ref, :process, _pid, reason} ->
+          {:error, {:task_crashed, reason}}
       after
         @stream_timeout -> {:error, :timeout_waiting_for_status}
       end
     end
 
-    @spec build_chunk_stream() :: Enumerable.t()
-    defp build_chunk_stream do
+    @spec build_chunk_stream(reference()) :: Enumerable.t()
+    defp build_chunk_stream(ref) do
       Stream.resource(
         fn -> :ok end,
         fn state ->
           receive do
             {:bedrock_stream, {:data, chunk}} -> {[chunk], state}
             {:bedrock_stream, :done} -> {:halt, state}
+            {:bedrock_stream, {:error, _reason}} -> {:halt, state}
+            {:DOWN, ^ref, :process, _pid, _reason} -> {:halt, state}
           after
             @stream_timeout -> {:halt, state}
           end

--- a/lib/llm_composer/providers/bedrock/http_client.ex
+++ b/lib/llm_composer/providers/bedrock/http_client.ex
@@ -95,14 +95,7 @@ if Code.ensure_loaded?(ExAws) do
         end)
 
       ref = Process.monitor(pid)
-
-      case await_response_metadata(ref) do
-        {:ok, {status, resp_headers}} ->
-          {:ok, %{status_code: status, headers: resp_headers, body: build_chunk_stream(ref)}}
-
-        {:error, reason} ->
-          {:error, %{reason: reason}}
-      end
+      handle_stream_response(ref)
     end
 
     # ---------------------------------------------------------------------------
@@ -144,14 +137,7 @@ if Code.ensure_loaded?(ExAws) do
         end)
 
       ref = Process.monitor(pid)
-
-      case await_response_metadata(ref) do
-        {:ok, {status, resp_headers}} ->
-          {:ok, %{status_code: status, headers: resp_headers, body: build_chunk_stream(ref)}}
-
-        {:error, reason} ->
-          {:error, %{reason: reason}}
-      end
+      handle_stream_response(ref)
     end
 
     @spec stream_mint_loop(Mint.HTTP.t(), Mint.Types.request_ref(), pid()) :: :ok
@@ -272,6 +258,20 @@ if Code.ensure_loaded?(ExAws) do
       end
     end
 
+    @spec handle_stream_response(reference()) :: {:ok, map()} | {:error, map()}
+    defp handle_stream_response(ref) do
+      case await_response_metadata(ref) do
+        {:ok, {status, resp_headers}} when status in 200..299 ->
+          {:ok, %{status_code: status, headers: resp_headers, body: build_chunk_stream(ref)}}
+
+        {:ok, {status, resp_headers}} ->
+          {:ok, %{status_code: status, headers: resp_headers, body: collect_error_body(ref)}}
+
+        {:error, reason} ->
+          {:error, %{reason: reason}}
+      end
+    end
+
     @spec await_response_metadata(reference()) ::
             {:ok, {pos_integer(), list()}} | {:error, term()}
     defp await_response_metadata(ref) do
@@ -297,6 +297,18 @@ if Code.ensure_loaded?(ExAws) do
           {:error, {:task_crashed, reason}}
       after
         @stream_timeout -> {:error, :timeout_waiting_for_status}
+      end
+    end
+
+    @spec collect_error_body(reference(), binary()) :: binary()
+    defp collect_error_body(ref, acc \\ "") do
+      receive do
+        {:bedrock_stream, {:data, chunk}} -> collect_error_body(ref, acc <> chunk)
+        {:bedrock_stream, :done} -> acc
+        {:bedrock_stream, {:error, _reason}} -> acc
+        {:DOWN, ^ref, :process, _pid, _reason} -> acc
+      after
+        @stream_timeout -> acc
       end
     end
 

--- a/lib/llm_composer/providers/bedrock/http_client.ex
+++ b/lib/llm_composer/providers/bedrock/http_client.ex
@@ -1,25 +1,30 @@
 if Code.ensure_loaded?(ExAws) do
   defmodule LlmComposer.Providers.Bedrock.HttpClient do
     @moduledoc """
-    ExAws HTTP client for Bedrock that delegates to the configured Tesla Finch adapter.
+    ExAws HTTP client for Bedrock using Mint by default, with optional Finch support.
 
-    When `stream: true` is present in `http_opts`, uses `Finch.stream/5` in a spawned
-    process, forwarding events as messages to the caller. Returns a lazy `Stream` as the
-    response body — required for the ConverseStream binary event-stream response.
+    When `stream: true` is present in `http_opts`, uses streaming HTTP via a spawned
+    process that forwards events as messages to the caller. Returns a lazy `Stream` as
+    the response body — required for the ConverseStream binary event-stream response.
 
-    For regular requests (or when streaming is not requested), uses `Finch.request/3`.
+    ## Default behaviour (Mint)
 
-    Reads the Finch process name from the `:llm_composer` `:tesla_adapter` config:
+    Uses `Mint.HTTP` directly for both streaming and regular requests. No additional
+    configuration is required since Mint is a required dependency of `llm_composer`.
+
+    ## Finch (optional)
+
+    If the `:llm_composer` `:tesla_adapter` config is set to a Finch adapter, Finch
+    is used instead of Mint:
 
         config :llm_composer, :tesla_adapter, {Tesla.Adapter.Finch, name: MyFinch}
 
-    If Finch is not configured, logs a warning and attempts a fallback via
-    `ExAws.Request.Hackney` when available.
+    Finch must be started in your supervision tree:
+
+        children = [{Finch, name: MyFinch}]
     """
 
     @behaviour ExAws.Request.HttpClient
-
-    alias ExAws.Request.Hackney
 
     require Logger
 
@@ -40,29 +45,30 @@ if Code.ensure_loaded?(ExAws) do
 
       case {stream, finch_name()} do
         {true, {:ok, name}} ->
-          stream_request(method, url, body, headers, name)
+          Logger.debug("[bedrock] http_client=finch name=#{name} stream=true")
+          stream_request_finch(method, url, body, headers, name)
 
         {true, :error} ->
-          Logger.warning(
-            "[bedrock] Finch not configured in :llm_composer :tesla_adapter — " <>
-              "falling back to full response. " <>
-              "Add `config :llm_composer, :tesla_adapter, {Tesla.Adapter.Finch, name: MyFinch}` " <>
-              "for proper stream support."
-          )
-
-          full_request_fallback(method, url, body, headers)
+          Logger.debug("[bedrock] http_client=mint stream=true")
+          stream_request_mint(method, url, body, headers)
 
         {false, {:ok, name}} ->
-          regular_request(method, url, body, headers, name)
+          Logger.debug("[bedrock] http_client=finch name=#{name} stream=false")
+          regular_request_finch(method, url, body, headers, name)
 
         {false, :error} ->
-          full_request_fallback(method, url, body, headers)
+          Logger.debug("[bedrock] http_client=mint stream=false")
+          regular_request_mint(method, url, body, headers)
       end
     end
 
-    @spec stream_request(atom(), binary(), binary(), list(), atom()) ::
+    # ---------------------------------------------------------------------------
+    # Finch streaming
+    # ---------------------------------------------------------------------------
+
+    @spec stream_request_finch(atom(), binary(), binary(), list(), atom()) ::
             {:ok, map()} | {:error, map()}
-    defp stream_request(method, url, body, headers, finch_name) do
+    defp stream_request_finch(method, url, body, headers, finch_name) do
       req = Finch.build(method, url, headers, body)
       caller = self()
 
@@ -86,24 +92,176 @@ if Code.ensure_loaded?(ExAws) do
 
       case await_response_metadata() do
         {:ok, {status, resp_headers}} ->
-          chunk_stream =
-            Stream.resource(
-              fn -> :ok end,
-              fn state ->
-                receive do
-                  {:bedrock_stream, {:data, chunk}} -> {[chunk], state}
-                  {:bedrock_stream, :done} -> {:halt, state}
-                after
-                  @stream_timeout -> {:halt, state}
-                end
-              end,
-              fn _state -> :ok end
-            )
-
-          {:ok, %{status_code: status, headers: resp_headers, body: chunk_stream}}
+          {:ok, %{status_code: status, headers: resp_headers, body: build_chunk_stream()}}
 
         {:error, reason} ->
           {:error, %{reason: reason}}
+      end
+    end
+
+    # ---------------------------------------------------------------------------
+    # Finch regular request
+    # ---------------------------------------------------------------------------
+
+    @spec regular_request_finch(atom(), binary(), binary(), list(), atom()) ::
+            {:ok, map()} | {:error, map()}
+    defp regular_request_finch(method, url, body, headers, finch_name) do
+      req = Finch.build(method, url, headers, body)
+
+      case Finch.request(req, finch_name) do
+        {:ok, %Finch.Response{status: status, headers: resp_headers, body: resp_body}} ->
+          {:ok, %{status_code: status, headers: resp_headers, body: resp_body}}
+
+        {:error, reason} ->
+          {:error, %{reason: reason}}
+      end
+    end
+
+    # ---------------------------------------------------------------------------
+    # Mint streaming
+    # ---------------------------------------------------------------------------
+
+    @spec stream_request_mint(atom(), binary(), binary(), list()) ::
+            {:ok, map()} | {:error, map()}
+    defp stream_request_mint(method, url, body, headers) do
+      caller = self()
+
+      Task.start(fn ->
+        case mint_connect_and_request(method, url, body, headers) do
+          {:ok, conn, ref} ->
+            stream_mint_loop(conn, ref, caller)
+
+          {:error, reason} ->
+            send(caller, {:bedrock_stream, {:error, reason}})
+            send(caller, {:bedrock_stream, :done})
+        end
+      end)
+
+      case await_response_metadata() do
+        {:ok, {status, resp_headers}} ->
+          {:ok, %{status_code: status, headers: resp_headers, body: build_chunk_stream()}}
+
+        {:error, reason} ->
+          {:error, %{reason: reason}}
+      end
+    end
+
+    @spec stream_mint_loop(Mint.HTTP.t(), Mint.Types.request_ref(), pid()) :: :ok
+    defp stream_mint_loop(conn, ref, caller) do
+      receive do
+        message ->
+          case Mint.HTTP.stream(conn, message) do
+            {:ok, conn, responses} ->
+              if process_mint_responses(responses, ref, caller) do
+                send(caller, {:bedrock_stream, :done})
+              else
+                stream_mint_loop(conn, ref, caller)
+              end
+
+            {:error, _conn, reason, _responses} ->
+              send(caller, {:bedrock_stream, {:error, reason}})
+              send(caller, {:bedrock_stream, :done})
+
+            :unknown ->
+              stream_mint_loop(conn, ref, caller)
+          end
+      after
+        @stream_timeout ->
+          send(caller, {:bedrock_stream, :done})
+      end
+    end
+
+    @spec process_mint_responses(list(), Mint.Types.request_ref(), pid()) :: boolean()
+    defp process_mint_responses([], _ref, _caller), do: false
+
+    defp process_mint_responses([{:status, ref, status} | rest], ref, caller) do
+      send(caller, {:bedrock_stream, {:status, status}})
+      process_mint_responses(rest, ref, caller)
+    end
+
+    defp process_mint_responses([{:headers, ref, resp_headers} | rest], ref, caller) do
+      send(caller, {:bedrock_stream, {:headers, resp_headers}})
+      process_mint_responses(rest, ref, caller)
+    end
+
+    defp process_mint_responses([{:data, ref, chunk} | rest], ref, caller) do
+      send(caller, {:bedrock_stream, {:data, chunk}})
+      process_mint_responses(rest, ref, caller)
+    end
+
+    defp process_mint_responses([{:done, ref} | _rest], ref, _caller), do: true
+
+    defp process_mint_responses([_other | rest], ref, caller),
+      do: process_mint_responses(rest, ref, caller)
+
+    # ---------------------------------------------------------------------------
+    # Mint regular request
+    # ---------------------------------------------------------------------------
+
+    @spec regular_request_mint(atom(), binary(), binary(), list()) ::
+            {:ok, map()} | {:error, map()}
+    defp regular_request_mint(method, url, body, headers) do
+      case mint_connect_and_request(method, url, body, headers) do
+        {:ok, conn, ref} ->
+          collect_mint_response(conn, ref, %{status: nil, headers: [], body: ""})
+
+        {:error, reason} ->
+          {:error, %{reason: reason}}
+      end
+    end
+
+    @spec collect_mint_response(Mint.HTTP.t(), Mint.Types.request_ref(), map()) ::
+            {:ok, map()} | {:error, map()}
+    defp collect_mint_response(conn, ref, acc) do
+      receive do
+        message ->
+          case Mint.HTTP.stream(conn, message) do
+            {:ok, conn, responses} ->
+              acc =
+                Enum.reduce(responses, acc, fn
+                  {:status, ^ref, status}, a -> %{a | status: status}
+                  {:headers, ^ref, hs}, a -> %{a | headers: a.headers ++ hs}
+                  {:data, ^ref, chunk}, a -> %{a | body: a.body <> chunk}
+                  {:done, ^ref}, a -> Map.put(a, :done, true)
+                  _other, a -> a
+                end)
+
+              if Map.get(acc, :done) do
+                {:ok, %{status_code: acc.status, headers: acc.headers, body: acc.body}}
+              else
+                collect_mint_response(conn, ref, acc)
+              end
+
+            {:error, _conn, reason, _responses} ->
+              {:error, %{reason: reason}}
+
+            :unknown ->
+              collect_mint_response(conn, ref, acc)
+          end
+      after
+        @stream_timeout -> {:error, %{reason: :timeout}}
+      end
+    end
+
+    # ---------------------------------------------------------------------------
+    # Shared helpers
+    # ---------------------------------------------------------------------------
+
+    @spec mint_connect_and_request(atom(), binary(), binary(), list()) ::
+            {:ok, Mint.HTTP.t(), Mint.Types.request_ref()} | {:error, term()}
+    defp mint_connect_and_request(method, url, body, headers) do
+      uri = URI.parse(url)
+      scheme = String.to_existing_atom(uri.scheme)
+      port = uri.port || if(scheme == :https, do: 443, else: 80)
+      path = if uri.query, do: "#{uri.path}?#{uri.query}", else: uri.path || "/"
+
+      method_str =
+        method
+        |> to_string()
+        |> String.upcase()
+
+      with {:ok, conn} <- Mint.HTTP.connect(scheme, uri.host, port) do
+        Mint.HTTP.request(conn, method_str, path, headers, body)
       end
     end
 
@@ -122,28 +280,20 @@ if Code.ensure_loaded?(ExAws) do
       end
     end
 
-    @spec regular_request(atom(), binary(), binary(), list(), atom()) ::
-            {:ok, map()} | {:error, map()}
-    defp regular_request(method, url, body, headers, finch_name) do
-      req = Finch.build(method, url, headers, body)
-
-      case Finch.request(req, finch_name) do
-        {:ok, %Finch.Response{status: status, headers: resp_headers, body: resp_body}} ->
-          {:ok, %{status_code: status, headers: resp_headers, body: resp_body}}
-
-        {:error, reason} ->
-          {:error, %{reason: reason}}
-      end
-    end
-
-    @spec full_request_fallback(atom(), binary(), binary(), list()) ::
-            {:ok, map()} | {:error, map()}
-    defp full_request_fallback(method, url, body, headers) do
-      if Code.ensure_loaded?(Hackney) do
-        Hackney.request(method, url, body, headers, [])
-      else
-        {:error, %{reason: :no_http_client_available}}
-      end
+    @spec build_chunk_stream() :: Enumerable.t()
+    defp build_chunk_stream do
+      Stream.resource(
+        fn -> :ok end,
+        fn state ->
+          receive do
+            {:bedrock_stream, {:data, chunk}} -> {[chunk], state}
+            {:bedrock_stream, :done} -> {:halt, state}
+          after
+            @stream_timeout -> {:halt, state}
+          end
+        end,
+        fn _state -> :ok end
+      )
     end
 
     @spec finch_name() :: {:ok, atom()} | :error

--- a/lib/llm_composer/providers/bedrock/stream_operation.ex
+++ b/lib/llm_composer/providers/bedrock/stream_operation.ex
@@ -36,7 +36,12 @@ if Code.ensure_loaded?(ExAws) do
       url = ExAws.Request.Url.build(operation, config)
       headers = [{"x-amz-content-sha256", ""} | operation.headers]
 
-      config = Map.put(config, :http_client, LlmComposer.Providers.Bedrock.HttpClient)
+      config =
+        if Application.get_env(:ex_aws, :http_client) do
+          config
+        else
+          Map.put(config, :http_client, LlmComposer.Providers.Bedrock.HttpClient)
+        end
 
       result =
         ExAws.Request.request(

--- a/lib/llm_composer/providers/bedrock/stream_operation.ex
+++ b/lib/llm_composer/providers/bedrock/stream_operation.ex
@@ -1,0 +1,62 @@
+if Code.ensure_loaded?(ExAws) do
+  defmodule LlmComposer.Providers.Bedrock.StreamOperation do
+    @moduledoc false
+
+    @doc """
+    Custom ExAws operation for the Bedrock ConverseStream endpoint.
+
+    Returns the raw binary body instead of JSON-decoding it, since the
+    ConverseStream response uses AWS Event Stream binary encoding.
+    """
+
+    defstruct http_method: :post,
+              path: "/",
+              data: %{},
+              headers: [],
+              service: nil
+
+    @type t :: %__MODULE__{}
+
+    @spec new(map(), String.t()) :: t()
+    def new(payload, model) do
+      %__MODULE__{
+        data: payload,
+        headers: [{"Content-Type", "application/json"}],
+        http_method: :post,
+        path: "/model/#{model}/converse-stream",
+        service: :"bedrock-runtime"
+      }
+    end
+  end
+
+  defimpl ExAws.Operation, for: LlmComposer.Providers.Bedrock.StreamOperation do
+    @spec perform(LlmComposer.Providers.Bedrock.StreamOperation.t(), map()) ::
+            {:ok, binary()} | {:error, term()}
+    def perform(operation, config) do
+      url = ExAws.Request.Url.build(operation, config)
+      headers = [{"x-amz-content-sha256", ""} | operation.headers]
+
+      config = Map.put(config, :http_client, LlmComposer.Providers.Bedrock.HttpClient)
+
+      result =
+        ExAws.Request.request(
+          operation.http_method,
+          url,
+          operation.data,
+          headers,
+          config,
+          operation.service
+        )
+
+      case ExAws.Request.default_aws_error(result) do
+        {:ok, %{body: body}} -> {:ok, body}
+        {:error, _} = error -> error
+      end
+    end
+
+    @spec stream!(LlmComposer.Providers.Bedrock.StreamOperation.t(), any()) :: no_return()
+    def stream!(_, _) do
+      raise ArgumentError, "stream! is not supported for Bedrock.StreamOperation"
+    end
+  end
+end

--- a/lib/llm_composer/providers/utils.ex
+++ b/lib/llm_composer/providers/utils.ex
@@ -274,6 +274,16 @@ defmodule LlmComposer.Providers.Utils do
     }
   end
 
+  defp transform_fn_to_tool(%LlmComposer.Function{} = function, :bedrock) do
+    %{
+      "toolSpec" => %{
+        "name" => function.name,
+        "description" => function.description,
+        "inputSchema" => %{"json" => function.schema}
+      }
+    }
+  end
+
   @spec maybe_put(map(), String.t(), any()) :: map()
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LlmComposer.MixProject do
   def project do
     [
       app: :llm_composer,
-      version: "0.18.2",
+      version: "0.19.0",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/llm_composer/cost/cost_assembler_test.exs
+++ b/test/llm_composer/cost/cost_assembler_test.exs
@@ -320,6 +320,83 @@ defmodule LlmComposer.Cost.CostAssemblerTest do
     end
   end
 
+  describe "get_cost_info/3 for Bedrock" do
+    test "extracts tokens from Bedrock response format" do
+      response = %{
+        "usage" => %{"inputTokens" => 16, "outputTokens" => 52}
+      }
+
+      {input, output, cached} = CostAssembler.extract_tokens(:bedrock, response)
+
+      assert input == 16
+      assert output == 52
+      assert cached == nil
+    end
+
+    test "assembles cost info for Bedrock with model from opts" do
+      response = %{
+        "usage" => %{"inputTokens" => 16, "outputTokens" => 52}
+      }
+
+      opts = [track_costs: true, model: "amazon.nova-lite-v1:0"]
+
+      result = CostAssembler.get_cost_info(:bedrock, response, opts)
+
+      assert is_struct(result, CostInfo)
+      assert result.provider_name == :bedrock
+      assert result.provider_model == "amazon.nova-lite-v1:0"
+      assert result.input_tokens == 16
+      assert result.output_tokens == 52
+      assert result.total_tokens == 68
+    end
+
+    test "assembles cost info for Bedrock with explicit pricing" do
+      response = %{
+        "usage" => %{"inputTokens" => 1_000_000, "outputTokens" => 500_000}
+      }
+
+      opts = [
+        track_costs: true,
+        model: "amazon.nova-lite-v1:0",
+        input_price_per_million: "0.06",
+        output_price_per_million: "0.24"
+      ]
+
+      result = CostAssembler.get_cost_info(:bedrock, response, opts)
+
+      assert Decimal.equal?(result.input_cost, Decimal.new("0.06"))
+      assert Decimal.equal?(result.output_cost, Decimal.new("0.12"))
+      assert Decimal.equal?(result.total_cost, Decimal.new("0.18"))
+    end
+
+    test "assembles cost info for Bedrock with models.dev pricing (region prefix stripped)" do
+      data = %{
+        "amazon-bedrock" => %{
+          "models" => %{
+            "amazon.nova-lite-v1:0" => %{
+              "cost" => %{"input" => 0.06, "output" => 0.24}
+            }
+          }
+        }
+      }
+
+      Ets.put("models_dev_api", data, 3600)
+
+      response = %{
+        "usage" => %{"inputTokens" => 1_000_000, "outputTokens" => 500_000}
+      }
+
+      opts = [track_costs: true, model: "eu.amazon.nova-lite-v1:0"]
+
+      result = CostAssembler.get_cost_info(:bedrock, response, opts)
+
+      assert result.provider_model == "eu.amazon.nova-lite-v1:0"
+      assert Decimal.equal?(result.input_cost, Decimal.new("0.06"))
+      assert Decimal.equal?(result.output_cost, Decimal.new("0.12"))
+      assert Decimal.equal?(result.total_cost, Decimal.new("0.18"))
+    end
+  end
+
   describe "get_cost_info/3 without track_costs option" do
     test "returns nil when track_costs is not set (defaults to false)" do
       response = %{

--- a/test/llm_composer/cost/pricing_test.exs
+++ b/test/llm_composer/cost/pricing_test.exs
@@ -67,6 +67,78 @@ defmodule LlmComposer.PricingTest do
     end
   end
 
+  describe "models_dev_fetcher/2 for bedrock" do
+    test "returns pricing for bedrock provider" do
+      data = %{
+        "amazon-bedrock" => %{
+          "models" => %{
+            "amazon.nova-lite-v1:0" => %{
+              "cost" => %{"input" => 0.06, "output" => 0.24, "cache_read" => 0.015}
+            }
+          }
+        }
+      }
+
+      Ets.put("models_dev_api", data, 3600)
+
+      result = Pricing.fetch_pricing(:bedrock, model: "amazon.nova-lite-v1:0")
+
+      assert result == [
+               cache_read_price_per_million: Decimal.new("0.015"),
+               input_price_per_million: Decimal.new("0.06"),
+               output_price_per_million: Decimal.new("0.24"),
+               currency: "USD"
+             ]
+    end
+
+    test "strips region prefix when exact match not found" do
+      data = %{
+        "amazon-bedrock" => %{
+          "models" => %{
+            "amazon.nova-lite-v1:0" => %{
+              "cost" => %{"input" => 0.06, "output" => 0.24}
+            }
+          }
+        }
+      }
+
+      Ets.put("models_dev_api", data, 3600)
+
+      result = Pricing.fetch_pricing(:bedrock, model: "eu.amazon.nova-lite-v1:0")
+
+      assert result == [
+               input_price_per_million: Decimal.new("0.06"),
+               output_price_per_million: Decimal.new("0.24"),
+               currency: "USD"
+             ]
+    end
+
+    test "uses region-prefixed entry when available" do
+      data = %{
+        "amazon-bedrock" => %{
+          "models" => %{
+            "eu.anthropic.claude-sonnet-4-6" => %{
+              "cost" => %{"input" => 0.4, "output" => 2.0}
+            },
+            "anthropic.claude-sonnet-4-6" => %{
+              "cost" => %{"input" => 0.3, "output" => 1.5}
+            }
+          }
+        }
+      }
+
+      Ets.put("models_dev_api", data, 3600)
+
+      result = Pricing.fetch_pricing(:bedrock, model: "eu.anthropic.claude-sonnet-4-6")
+
+      assert result == [
+               input_price_per_million: Decimal.new("0.4"),
+               output_price_per_million: Decimal.new("2.0"),
+               currency: "USD"
+             ]
+    end
+  end
+
   describe "models_dev_fetcher/2" do
     test "returns nil for unsupported providers" do
       result = ModelsDev.fetch_pricing(:ollama, "llama3.1")

--- a/test/llm_composer/providers/bedrock_http_client_test.exs
+++ b/test/llm_composer/providers/bedrock_http_client_test.exs
@@ -1,0 +1,77 @@
+if Code.ensure_loaded?(ExAws) do
+  defmodule LlmComposer.Providers.Bedrock.HttpClientTest do
+    use ExUnit.Case, async: true
+
+    alias LlmComposer.Providers.Bedrock.HttpClient
+
+    setup do
+      Application.delete_env(:llm_composer, :tesla_adapter)
+      bypass = Bypass.open()
+      {:ok, bypass: bypass}
+    end
+
+    describe "request/5 non-streaming via Mint" do
+      test "returns ok with status and body on 200", %{bypass: bypass} do
+        Bypass.expect_once(bypass, "POST", "/test", fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("content-type", "application/json")
+          |> Plug.Conn.resp(200, ~s({"result":"ok"}))
+        end)
+
+        assert {:ok, %{status_code: 200, body: ~s({"result":"ok"})}} =
+                 HttpClient.request(:post, endpoint(bypass, "/test"), "", [], [])
+      end
+
+      test "returns ok with non-200 status code", %{bypass: bypass} do
+        Bypass.expect_once(bypass, "POST", "/test", fn conn ->
+          Plug.Conn.resp(conn, 500, "internal error")
+        end)
+
+        assert {:ok, %{status_code: 500, body: "internal error"}} =
+                 HttpClient.request(:post, endpoint(bypass, "/test"), "", [], [])
+      end
+    end
+
+    describe "request/5 streaming via Mint" do
+      test "returns lazy stream that yields body chunks", %{bypass: bypass} do
+        Bypass.expect_once(bypass, "POST", "/stream", fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("content-type", "application/octet-stream")
+          |> Plug.Conn.resp(200, "hello world")
+        end)
+
+        assert {:ok, %{status_code: 200, body: stream}} =
+                 HttpClient.request(:post, endpoint(bypass, "/stream"), "", [], stream: true)
+
+        assert Enum.join(stream) == "hello world"
+      end
+
+      test "returns status and headers before consuming stream", %{bypass: bypass} do
+        Bypass.expect_once(bypass, "POST", "/stream", fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("x-custom", "value")
+          |> Plug.Conn.resp(200, "data")
+        end)
+
+        assert {:ok, %{status_code: 200, headers: headers}} =
+                 HttpClient.request(:post, endpoint(bypass, "/stream"), "", [], stream: true)
+
+        assert Enum.any?(headers, fn {k, _v} -> k == "x-custom" end)
+      end
+    end
+
+    describe "request/5 connection errors" do
+      test "returns error fast on refused connection (non-streaming)" do
+        assert {:error, %{reason: _}} =
+                 HttpClient.request(:post, "http://localhost:1/test", "", [], [])
+      end
+
+      test "returns error fast on refused connection (streaming)" do
+        assert {:error, %{reason: _}} =
+                 HttpClient.request(:post, "http://localhost:1/test", "", [], stream: true)
+      end
+    end
+
+    defp endpoint(bypass, path), do: "http://localhost:#{bypass.port}#{path}"
+  end
+end


### PR DESCRIPTION
## Summary

- Add streaming support for Amazon Bedrock via the `ConverseStream` API, including AWS Event Stream binary frame parsing
- Add tool calls (function calling) support for Bedrock: request serialization, response extraction (`toolUse`/`toolResult`), and consecutive tool-result merging required by the Bedrock API
- Introduce `LlmComposer.Providers.Bedrock.HttpClient` — a custom ExAws HTTP client that uses **Mint by default** for both streaming and regular requests, with optional Finch support when configured via `:tesla_adapter`
- Use the custom HTTP client automatically when `config :ex_aws, http_client` is not explicitly set (both streaming and non-streaming paths)
- Add `ProviderStreamChunk.Parser.Bedrock` to normalize stream events (`text_delta`, `done`, `usage`) into the shared `StreamChunk` format

## How to check?

With this livebook, using aws creds

<details>
<summary>Example livebook steps</summary>

# Bedrock Stream

```elixir
Mix.install(
  [
    {:finch, "~> 0.21.0"},
    # {:llm_composer, "~> 0.18.2"},
    {:llm_composer, path: "<path to local llm_composer with branch>"},
    {:ex_aws, "~> 2.6"},
    {:jason, "~> 1.4"},
    {:kino, "~> 0.19.0"}
  ],
  config: [
    llm_composer: [
    #   tesla_adapter: {Tesla.Adapter.Finch, name: MyFinch}
    ],
    ex_aws: [
      # http_client: ExAws.Finch,
      "bedrock-runtime": [
        access_key_id: System.get_env("LB_AWS_KEY"),
        secret_access_key: System.get_env("LB_AWS_SECRET"),
        region: "eu-west-1"
      ]
    ]
  ]
)
```

## Setup

```elixir
{:ok, _} = Finch.start_link(name: MyFinch)

defmodule ExAws.Finch do
  @moduledoc """
  ExAws HTTP client implementation for Req.
  """

  @behaviour ExAws.Request.HttpClient

  @impl ExAws.Request.HttpClient
  def request(method, url, body, headers, http_opts) do
    IO.inspect http_opts, label: "--- http opts"
    
    request = Finch.build(method, url, headers, body)

    # case Req.request(request, method: method, url: url, body: body, headers: headers) do
    case Finch.request(request, MyFinch) do
      {:ok, %Finch.Response{} = response} ->
        response = %{
          status_code: response.status,
          headers: response.headers,
          body: response.body,
        }

        {:ok, response}

      {:error, reason} ->
        {:error, %{reason: reason}}
    end
  end
end
```

## Usage

```elixir
defmodule MyBedrockChat do
  @settings %LlmComposer.Settings{
    providers: [
      {LlmComposer.Providers.Bedrock, [model: "eu.amazon.nova-lite-v1:0"]}
    ],
    system_prompt: "You are an expert in Quantum Field Theory."
  }

  def simple_chat(msg) do
    LlmComposer.simple_chat(@settings, msg)
  end
end

if true do
  {:ok, res} =
    MyBedrockChat.simple_chat("What is the wave function collapse? Just a few sentences")

  Kino.Markdown.new(res.main_response.content)
end
```

```elixir
defmodule MyBedrockStreamChat do
  def settings(stream) do
    %LlmComposer.Settings{
      providers: [
        {LlmComposer.Providers.Bedrock, [model: "eu.amazon.nova-lite-v1:0"]}
      ],
      stream_response: stream,
      system_prompt: "You are an expert in Quantum Field Theory."
    }
  end

  def simple_chat(msg, stream \\ false) do
    LlmComposer.simple_chat(settings(stream), msg)
  end
end

msg = """
in one sentence, why 42 is the meaning of life?
"""
msg = """
why aws is awesome in three words or a bit more??
"""

stream = true
{:ok, res} = MyBedrockStreamChat.simple_chat(msg, stream)

if stream do
  IO.inspect(res, label: "--- full res")

  res.stream
  |> LlmComposer.parse_stream_response(res.provider)
  |> Enum.each(fn chunk ->
    # IO.inspect(chunk, label: "--- chunk")
    IO.write(chunk.text)
  end)
else
  Kino.Markdown.new(res.main_response.content)
end
```

## Tool Calls

```elixir
alias LlmComposer.Function
alias LlmComposer.FunctionCallHelpers
alias LlmComposer.FunctionExecutor
alias LlmComposer.LlmResponse
alias LlmComposer.Message
alias LlmComposer.Providers.Bedrock

# Actual implementation module for the calculator tool
defmodule Calculator do
  def calculate(%{"expression" => expression}) do
    try do
      {result, _binding} = Code.eval_string(expression)
      result
    rescue
      _ -> {:error, "invalid expression"}
    end
  end
end

# Function struct used by FunctionExecutor to look up and invoke the tool
calculator_fn = %Function{
  mf: {Calculator, :calculate},
  name: "calculator",
  description: "Calculator for math expressions",
  schema: %{
    type: "object",
    properties: %{
      expression: %{type: "string", example: "2 ** 2 + 3"}
    },
    required: ["expression"]
  }
}

functions = [calculator_fn]
```

```elixir
tool_settings = %LlmComposer.Settings{
  providers: [
    {Bedrock, [model: "eu.amazon.nova-lite-v1:0", functions: functions]}
  ],
  system_prompt: "You are a helpful assistant."
}

user_message = Message.new(:user, """
Help me know the result of these calculations:

* 2 ** 12
* 3 + 2 * 5
""")

{:ok, first_res} = LlmComposer.run_completion(tool_settings, [user_message])

IO.inspect(first_res.main_response.function_calls, label: "function_calls")
```

```elixir
# Execute each tool call and populate FunctionCall.result
executed_calls =
  first_res
  |> LlmResponse.function_calls()
  |> Enum.map(fn call ->
    {:ok, executed_call} = FunctionExecutor.execute(call, functions)
    executed_call
  end)

IO.inspect(executed_calls, label: "executed_calls")
```

```elixir
# Build messages for the second turn: assistant (with tool use) + tool results
tool_result_messages = FunctionCallHelpers.build_tool_result_messages(executed_calls)

assistant_with_tools =
  FunctionCallHelpers.build_assistant_with_tools(Bedrock, first_res, user_message)

messages = [user_message, assistant_with_tools] ++ tool_result_messages

{:ok, final_res} = LlmComposer.run_completion(tool_settings, messages)

Kino.Markdown.new(final_res.main_response.content)
```

