### PR TITLE
fix google thinking chunks

### DIFF
--- a/lib/llm_composer/provider_stream_chunk/parser/google.ex
+++ b/lib/llm_composer/provider_stream_chunk/parser/google.ex
@@ -9,7 +9,7 @@ defmodule LlmComposer.ProviderStreamChunk.Parser.Google do
   def parse(%{"candidates" => [candidate | _]} = raw, _provider, opts) do
     content = candidate["content"] || %{}
     parts = content["parts"] || []
-    text = extract_text(parts)
+    {text, reasoning} = extract_text_and_reasoning(parts)
     tool_calls = FunctionCallExtractors.from_google_parts(content)
     finish_reason = candidate["finishReason"] || candidate["finish_reason"]
     usage = format_usage(raw["usageMetadata"])
@@ -21,6 +21,9 @@ defmodule LlmComposer.ProviderStreamChunk.Parser.Google do
 
         text not in [nil, ""] ->
           :text_delta
+
+        reasoning not in [nil, ""] ->
+          :reasoning_delta
 
         is_list(tool_calls) ->
           :tool_call_delta
@@ -34,6 +37,7 @@ defmodule LlmComposer.ProviderStreamChunk.Parser.Google do
        provider: :google,
        type: type,
        text: text,
+       reasoning: reasoning,
        tool_calls: tool_calls,
        usage: usage,
        cost_info: build_cost_info(raw, usage, opts),
@@ -44,9 +48,11 @@ defmodule LlmComposer.ProviderStreamChunk.Parser.Google do
 
   def parse(_, _, _), do: :skip
 
-  defp extract_text(parts) do
-    text = Enum.map_join(parts, "", &Map.get(&1, "text", ""))
-    if text == "", do: nil, else: text
+  defp extract_text_and_reasoning(parts) do
+    {thought_parts, text_parts} = Enum.split_with(parts, &Map.get(&1, "thought"))
+    text = Enum.map_join(text_parts, "", &Map.get(&1, "text", ""))
+    reasoning = Enum.map_join(thought_parts, "", &Map.get(&1, "text", ""))
+    {if(text == "", do: nil, else: text), if(reasoning == "", do: nil, else: reasoning)}
   end
 
   defp format_usage(

--- a/lib/llm_composer/provider_stream_chunk/parser/google.ex
+++ b/lib/llm_composer/provider_stream_chunk/parser/google.ex
@@ -50,10 +50,10 @@ defmodule LlmComposer.ProviderStreamChunk.Parser.Google do
 
   defp extract_text_and_reasoning(parts) do
     {thought_parts, text_parts} = Enum.split_with(parts, &Map.get(&1, "thought"))
-    text = Enum.map_join(text_parts, "", &Map.get(&1, "text", ""))
-    reasoning = Enum.map_join(thought_parts, "", &Map.get(&1, "text", ""))
-    text = if text == "", do: nil, else: text
-    reasoning = if reasoning == "", do: nil, else: reasoning
+    raw_text = Enum.map_join(text_parts, "", &Map.get(&1, "text", ""))
+    raw_reasoning = Enum.map_join(thought_parts, "", &Map.get(&1, "text", ""))
+    text = if raw_text == "", do: nil, else: raw_text
+    reasoning = if raw_reasoning == "", do: nil, else: raw_reasoning
 
     {text, reasoning}
   end

--- a/lib/llm_composer/provider_stream_chunk/parser/google.ex
+++ b/lib/llm_composer/provider_stream_chunk/parser/google.ex
@@ -52,7 +52,10 @@ defmodule LlmComposer.ProviderStreamChunk.Parser.Google do
     {thought_parts, text_parts} = Enum.split_with(parts, &Map.get(&1, "thought"))
     text = Enum.map_join(text_parts, "", &Map.get(&1, "text", ""))
     reasoning = Enum.map_join(thought_parts, "", &Map.get(&1, "text", ""))
-    {if(text == "", do: nil, else: text), if(reasoning == "", do: nil, else: reasoning)}
+    text = if text == "", do: nil, else: text
+    reasoning = if reasoning == "", do: nil, else: reasoning
+
+    {text, reasoning}
   end
 
   defp format_usage(

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LlmComposer.MixProject do
   def project do
     [
       app: :llm_composer,
-      version: "0.19.1",
+      version: "0.19.2",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/llm_composer/stream_chunk_test.exs
+++ b/test/llm_composer/stream_chunk_test.exs
@@ -183,6 +183,40 @@ defmodule LlmComposer.StreamChunkTest do
              } = chunk
     end
 
+    test "Google chunk with thought part becomes :reasoning_delta" do
+      data =
+        ~s(data: {"candidates":[{"content":{"role":"model","parts":[{"text":"I should think about this","thought":true}]}}]})
+
+      [chunk] =
+        [data]
+        |> LlmComposer.parse_stream_response(:google)
+        |> Enum.to_list()
+
+      assert %StreamChunk{
+               provider: :google,
+               type: :reasoning_delta,
+               text: nil,
+               reasoning: "I should think about this"
+             } = chunk
+    end
+
+    test "Google chunk with mixed thought and text parts splits correctly" do
+      data =
+        ~s(data: {"candidates":[{"content":{"role":"model","parts":[{"text":"thinking...","thought":true},{"text":"the answer"}]}}]})
+
+      [chunk] =
+        [data]
+        |> LlmComposer.parse_stream_response(:google)
+        |> Enum.to_list()
+
+      assert %StreamChunk{
+               provider: :google,
+               type: :text_delta,
+               text: "the answer",
+               reasoning: "thinking..."
+             } = chunk
+    end
+
     test "Google done chunk with functionCall still becomes :done" do
       data =
         ~s(data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"http_client","args":{}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}})


### PR DESCRIPTION
  ## Problem

The Google stream chunk parser did not handle Gemini's thinking/reasoning parts. When a model responds with "thought": true parts in the parts array, they were being concatenated together with regular text parts and surfaced as :text_delta — reasoning content was leaking into the text output and there was no way to distinguish it.

Additionally, the StreamChunk struct was not being populated with a reasoning field and no :reasoning_delta chunk type was emitted for Google responses, so consumers had no way to observe or react to reasoning steps separately from final text.

 ## Fix

  - Split extract_text/1 into a single extract_text_and_reasoning/1 function that partitions parts by the "thought" flag in one pass using Enum.split_with/2, cleanly separating reasoning from text content.
  - Populate the reasoning field on the StreamChunk struct for Google responses.
  - Emit :reasoning_delta as chunk type when only thought parts are present (and no text).
  - Added tests covering a pure reasoning chunk and a mixed thought + text chunk.