### PR TITLE
Fix SSE streaming options for Tesla Mint

### DIFF
--- a/lib/llm_composer/provider_response/parser/google.ex
+++ b/lib/llm_composer/provider_response/parser/google.ex
@@ -22,6 +22,16 @@ defmodule LlmComposer.ProviderResponse.Parser.Google do
      })}
   end
 
+  def parse({:ok, %{response: %Stream{} = stream}} = raw_result, :google, _opts) do
+    {:ok,
+     LlmResponse.new(%{
+       provider: :google,
+       status: :ok,
+       stream: stream,
+       raw: raw_result
+     })}
+  end
+
   def parse({:ok, %{response: response}}, :google, opts) do
     [first_candidate | _] = response["candidates"]
     content = first_candidate["content"]

--- a/lib/llm_composer/provider_response/parser/ollama.ex
+++ b/lib/llm_composer/provider_response/parser/ollama.ex
@@ -18,6 +18,16 @@ defmodule LlmComposer.ProviderResponse.Parser.Ollama do
      })}
   end
 
+  def parse({:ok, %{response: %Stream{} = stream}} = raw_result, :ollama, _opts) do
+    {:ok,
+     LlmResponse.new(%{
+       provider: :ollama,
+       status: :ok,
+       stream: stream,
+       raw: raw_result
+     })}
+  end
+
   def parse({:ok, %{response: response}} = raw_result, :ollama, _opts) when is_list(response) do
     if Enum.all?(response, &is_binary/1) do
       {:ok,

--- a/lib/llm_composer/provider_response/parser/open_ai.ex
+++ b/lib/llm_composer/provider_response/parser/open_ai.ex
@@ -24,6 +24,16 @@ defmodule LlmComposer.ProviderResponse.Parser.OpenAI do
      })}
   end
 
+  def parse({:ok, %{response: %Stream{} = stream}} = raw_result, provider, _opts) do
+    {:ok,
+     LlmResponse.new(%{
+       provider: provider,
+       status: :ok,
+       stream: stream,
+       raw: raw_result
+     })}
+  end
+
   def parse({:ok, %{response: response} = provider_response}, provider, opts) do
     if streamed_chunks?(response) do
       {:ok,

--- a/lib/llm_composer/providers/utils.ex
+++ b/lib/llm_composer/providers/utils.ex
@@ -209,9 +209,19 @@ defmodule LlmComposer.Providers.Utils do
   @spec get_req_opts(keyword()) :: keyword()
   def get_req_opts(opts) do
     if Keyword.get(opts, :stream_response) do
-      [adapter: [response: :stream]]
+      [adapter: stream_adapter_opts()]
     else
       []
+    end
+  end
+
+  defp stream_adapter_opts do
+    case Application.get_env(:llm_composer, :tesla_adapter, Tesla.Adapter.Mint) do
+      {Tesla.Adapter.Finch, _opts} -> [response: :stream]
+      Tesla.Adapter.Finch -> [response: :stream]
+      {Tesla.Adapter.Mint, _opts} -> [body_as: :stream]
+      Tesla.Adapter.Mint -> [body_as: :stream]
+      _other -> [response: :stream]
     end
   end
 

--- a/test/llm_composer/providers/utils_test.exs
+++ b/test/llm_composer/providers/utils_test.exs
@@ -72,8 +72,36 @@ defmodule LlmComposer.Providers.UtilsTest do
     end
   end
 
-  test "get_req_opts returns stream adapter when stream_response true" do
+  test "get_req_opts returns finch stream adapter when configured adapter is finch" do
+    original = Application.get_env(:llm_composer, :tesla_adapter)
+
+    Application.put_env(:llm_composer, :tesla_adapter, {Tesla.Adapter.Finch, name: MyFinch})
+
+    on_exit(fn ->
+      if is_nil(original) do
+        Application.delete_env(:llm_composer, :tesla_adapter)
+      else
+        Application.put_env(:llm_composer, :tesla_adapter, original)
+      end
+    end)
+
     assert Utils.get_req_opts(stream_response: true) == [adapter: [response: :stream]]
+  end
+
+  test "get_req_opts returns mint stream adapter when configured adapter is mint" do
+    original = Application.get_env(:llm_composer, :tesla_adapter)
+
+    Application.put_env(:llm_composer, :tesla_adapter, Tesla.Adapter.Mint)
+
+    on_exit(fn ->
+      if is_nil(original) do
+        Application.delete_env(:llm_composer, :tesla_adapter)
+      else
+        Application.put_env(:llm_composer, :tesla_adapter, original)
+      end
+    end)
+
+    assert Utils.get_req_opts(stream_response: true) == [adapter: [body_as: :stream]]
   end
 
   test "get_req_opts returns empty list when stream_response not set" do


### PR DESCRIPTION
## Summary

Fixes SSE streaming when using `Tesla.Adapter.Mint`.

`get_req_opts/1` now selects the correct Tesla adapter option for streamed responses:

- `Tesla.Adapter.Finch`: `response: :stream`
- `Tesla.Adapter.Mint`: `body_as: :stream`

This also updates the provider response parsers to keep Mint streamed bodies on the streaming path. Mint returns streamed bodies as `%Stream{}`, so Ollama, Google, and OpenAI responses now treat that shape as a stream instead of trying to parse it as a non-streaming JSON response.

## Why

Mint expects streamed response bodies to be enabled with `body_as: :stream`, while Finch uses `response: :stream`. Using the Finch option with Mint prevents SSE responses from being handled correctly.

Without handling Mint’s `%Stream{}` body shape, provider parsers can fall through to their non-streaming response parsing and crash when they try to access JSON fields on a stream.

## Tests

- Added coverage for Finch and Mint adapter stream options
- Verified Ollama, Google, and OpenAI streaming parser paths
- Ran `mix precommit`