### PR TITLE
Add GroupedFunctions credo check and enforce public/private grouping

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -41,7 +41,9 @@
       # If you create your own checks, you must specify the source files for
       # them here, so they can be loaded by Credo before running the analysis.
       #
-      requires: [],
+      requires: [
+        "./lib/llm_composer/credo_checks/grouped_functions.ex"
+      ],
       #
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:
@@ -101,6 +103,7 @@
           {Credo.Check.Readability.ModuleAttributeNames, []},
           {Credo.Check.Readability.ModuleDoc, []},
           {Credo.Check.Readability.ModuleNames, []},
+          {LlmComposer.CredoChecks.GroupedFunctions, []},
           {Credo.Check.Readability.ParenthesesInCondition, []},
           {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
           {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},

--- a/lib/llm_composer/credo_checks/grouped_functions.ex
+++ b/lib/llm_composer/credo_checks/grouped_functions.ex
@@ -1,0 +1,84 @@
+if Code.ensure_loaded?(Credo.Check) do
+  defmodule LlmComposer.CredoChecks.GroupedFunctions do
+    @moduledoc false
+
+    use Credo.Check,
+      base_priority: :normal,
+      category: :readability,
+      explanations: [
+        check: """
+        Public and private functions must be grouped, not interleaved.
+        Keep all `def` clauses together and all `defp` clauses together.
+        """
+      ]
+
+    alias Credo.IssueMeta
+    alias Credo.SourceFile
+
+    @impl Credo.Check
+    def run(%SourceFile{} = source_file, params) do
+      issue_meta = IssueMeta.for(source_file, params)
+
+      source_file
+      |> Credo.Code.prewalk(&traverse(&1, &2), [])
+      |> check_grouping(issue_meta)
+    end
+
+    defp traverse({kind, meta, [head | _]} = ast, acc) when kind in [:def, :defp] do
+      name = extract_name(head)
+      visibility = if kind == :def, do: :public, else: :private
+      {ast, [{visibility, name, meta[:line]} | acc]}
+    end
+
+    defp traverse(ast, acc), do: {ast, acc}
+
+    defp extract_name({:when, _, [head | _]}), do: extract_name(head)
+    defp extract_name({name, _, _}) when is_atom(name), do: name
+    defp extract_name(_), do: :unknown
+
+    defp check_grouping(collected, issue_meta) do
+      functions =
+        collected
+        |> Enum.reverse()
+        |> Enum.dedup_by(fn {visibility, name, _line} -> {visibility, name} end)
+
+      blocks = Enum.chunk_by(functions, fn {visibility, _, _} -> visibility end)
+
+      duplicated_visibilities =
+        blocks
+        |> Enum.map(fn [{visibility, _, _} | _] -> visibility end)
+        |> Enum.frequencies()
+        |> Enum.filter(fn {_visibility, count} -> count > 1 end)
+        |> Enum.map(fn {visibility, _} -> visibility end)
+
+      blocks
+      |> mark_offending_blocks(duplicated_visibilities)
+      |> Enum.map(fn {visibility, name, line} ->
+        build_issue(visibility, name, line, issue_meta)
+      end)
+    end
+
+    defp mark_offending_blocks(blocks, duplicated_visibilities) do
+      {offending, _seen} =
+        Enum.reduce(blocks, {[], MapSet.new()}, fn [{visibility, name, line} | _], {acc, seen} ->
+          if visibility in duplicated_visibilities and MapSet.member?(seen, visibility) do
+            {[{visibility, name, line} | acc], seen}
+          else
+            {acc, MapSet.put(seen, visibility)}
+          end
+        end)
+
+      Enum.reverse(offending)
+    end
+
+    defp build_issue(visibility, name, line_no, issue_meta) do
+      format_issue(
+        issue_meta,
+        message:
+          "#{visibility} function `#{name}` breaks grouping; keep all public and private functions grouped.",
+        trigger: to_string(name),
+        line_no: line_no
+      )
+    end
+  end
+end

--- a/lib/llm_composer/function_call_extractors.ex
+++ b/lib/llm_composer/function_call_extractors.ex
@@ -11,19 +11,6 @@ defmodule LlmComposer.FunctionCallExtractors do
 
   def from_tool_calls(_), do: nil
 
-  defp build_tool_call(tool_call) do
-    function_info = tool_call["function"]
-
-    %FunctionCall{
-      id: tool_call["id"],
-      name: function_info["name"],
-      arguments: function_info["arguments"],
-      type: tool_call["type"],
-      metadata: %{},
-      result: nil
-    }
-  end
-
   @spec from_google_parts(map()) :: [FunctionCall.t()] | nil
   def from_google_parts(%{"parts" => parts}) when is_list(parts) do
     function_calls =
@@ -73,4 +60,17 @@ defmodule LlmComposer.FunctionCallExtractors do
   end
 
   def from_bedrock_content(_), do: nil
+
+  defp build_tool_call(tool_call) do
+    function_info = tool_call["function"]
+
+    %FunctionCall{
+      id: tool_call["id"],
+      name: function_info["name"],
+      arguments: function_info["arguments"],
+      type: tool_call["type"],
+      metadata: %{},
+      result: nil
+    }
+  end
 end

--- a/lib/llm_composer/helpers.ex
+++ b/lib/llm_composer/helpers.ex
@@ -28,14 +28,6 @@ defmodule LlmComposer.Helpers do
 
   def normalize_json(data), do: data
 
-  defp ordered_object?(data) do
-    data != [] and
-      Enum.all?(data, fn
-        {key, _value} when is_binary(key) or is_atom(key) -> true
-        _other -> false
-      end)
-  end
-
   @doc """
   Returns the configured JSON engine module.
 
@@ -48,6 +40,14 @@ defmodule LlmComposer.Helpers do
       nil -> if Code.ensure_loaded?(JSON), do: JSON, else: Jason
       engine -> engine
     end
+  end
+
+  defp ordered_object?(data) do
+    data != [] and
+      Enum.all?(data, fn
+        {key, _value} when is_binary(key) or is_atom(key) -> true
+        _other -> false
+      end)
   end
 
   defp normalize_key(key) when is_binary(key), do: key

--- a/lib/llm_composer/providers/utils.ex
+++ b/lib/llm_composer/providers/utils.ex
@@ -108,6 +108,85 @@ defmodule LlmComposer.Providers.Utils do
     |> merge_consecutive_function_responses()
   end
 
+  @spec cleanup_body(map()) :: map()
+  def cleanup_body(body) do
+    body
+    |> Enum.reject(fn
+      {_param, nil} -> true
+      {_param, []} -> true
+      _other -> false
+    end)
+    |> Map.new()
+  end
+
+  @spec merge_request_params(map(), map()) :: map()
+  def merge_request_params(base_req, req_params) do
+    Enum.reduce(req_params, base_req, fn {key, value}, acc ->
+      existing = Map.get(acc, key)
+
+      if is_map(existing) and is_map(value) do
+        Map.put(acc, key, Map.merge(existing, value))
+      else
+        Map.put(acc, key, value)
+      end
+    end)
+  end
+
+  @spec get_tools([LlmComposer.Function.t()] | nil, atom) :: nil | [map()]
+  def get_tools(nil, _provider), do: nil
+
+  def get_tools(functions, provider) when is_list(functions) do
+    Enum.map(functions, &transform_fn_to_tool(&1, provider))
+  end
+
+  @spec get_req_opts(keyword()) :: keyword()
+  def get_req_opts(opts) do
+    if Keyword.get(opts, :stream_response) do
+      [adapter: stream_adapter_opts()]
+    else
+      []
+    end
+  end
+
+  @doc """
+  Reads a configuration value for the given provider key.
+
+  Priority order:
+  1. Get from `opts` keyword list.
+  2. Get from application config `:llm_composer`, provider_key.
+  3. Use provided `default` value.
+  """
+  @spec get_open_ai_key(keyword()) :: String.t()
+  def get_open_ai_key(opts) do
+    case get_config(:open_ai, :api_key, opts) do
+      nil -> raise LlmComposer.Errors.MissingKeyError
+      key -> key
+    end
+  end
+
+  @spec get_open_ai_request_opts(keyword()) :: keyword()
+  def get_open_ai_request_opts(opts) do
+    timeout = Keyword.get(opts, :timeout, Application.get_env(:llm_composer, :timeout, 50_000))
+    adapter_opts = [receive_timeout: timeout]
+
+    opts
+    |> get_req_opts()
+    |> Keyword.update(:adapter, adapter_opts, &Keyword.merge(&1, adapter_opts))
+  end
+
+  @spec get_config(atom, atom, keyword, any) :: any
+  def get_config(provider_key, key, opts, default \\ nil) do
+    case Keyword.get(opts, key) do
+      nil ->
+        :llm_composer
+        |> Application.get_env(provider_key, [])
+        |> Keyword.get(key, default)
+
+      value ->
+        value
+    end
+  end
+
   @spec build_google_assistant_message(
           String.t() | nil,
           [LlmComposer.FunctionCall.t()] | nil,
@@ -175,46 +254,6 @@ defmodule LlmComposer.Providers.Utils do
     |> Enum.reverse()
   end
 
-  @spec cleanup_body(map()) :: map()
-  def cleanup_body(body) do
-    body
-    |> Enum.reject(fn
-      {_param, nil} -> true
-      {_param, []} -> true
-      _other -> false
-    end)
-    |> Map.new()
-  end
-
-  @spec merge_request_params(map(), map()) :: map()
-  def merge_request_params(base_req, req_params) do
-    Enum.reduce(req_params, base_req, fn {key, value}, acc ->
-      existing = Map.get(acc, key)
-
-      if is_map(existing) and is_map(value) do
-        Map.put(acc, key, Map.merge(existing, value))
-      else
-        Map.put(acc, key, value)
-      end
-    end)
-  end
-
-  @spec get_tools([LlmComposer.Function.t()] | nil, atom) :: nil | [map()]
-  def get_tools(nil, _provider), do: nil
-
-  def get_tools(functions, provider) when is_list(functions) do
-    Enum.map(functions, &transform_fn_to_tool(&1, provider))
-  end
-
-  @spec get_req_opts(keyword()) :: keyword()
-  def get_req_opts(opts) do
-    if Keyword.get(opts, :stream_response) do
-      [adapter: stream_adapter_opts()]
-    else
-      []
-    end
-  end
-
   defp stream_adapter_opts do
     case Application.get_env(:llm_composer, :tesla_adapter, Tesla.Adapter.Mint) do
       {Tesla.Adapter.Finch, _opts} -> [response: :stream]
@@ -222,45 +261,6 @@ defmodule LlmComposer.Providers.Utils do
       {Tesla.Adapter.Mint, _opts} -> [body_as: :stream]
       Tesla.Adapter.Mint -> [body_as: :stream]
       _other -> [response: :stream]
-    end
-  end
-
-  @doc """
-  Reads a configuration value for the given provider key.
-
-  Priority order:
-  1. Get from `opts` keyword list.
-  2. Get from application config `:llm_composer`, provider_key.
-  3. Use provided `default` value.
-  """
-  @spec get_open_ai_key(keyword()) :: String.t()
-  def get_open_ai_key(opts) do
-    case get_config(:open_ai, :api_key, opts) do
-      nil -> raise LlmComposer.Errors.MissingKeyError
-      key -> key
-    end
-  end
-
-  @spec get_open_ai_request_opts(keyword()) :: keyword()
-  def get_open_ai_request_opts(opts) do
-    timeout = Keyword.get(opts, :timeout, Application.get_env(:llm_composer, :timeout, 50_000))
-    adapter_opts = [receive_timeout: timeout]
-
-    opts
-    |> get_req_opts()
-    |> Keyword.update(:adapter, adapter_opts, &Keyword.merge(&1, adapter_opts))
-  end
-
-  @spec get_config(atom, atom, keyword, any) :: any
-  def get_config(provider_key, key, opts, default \\ nil) do
-    case Keyword.get(opts, key) do
-      nil ->
-        :llm_composer
-        |> Application.get_env(provider_key, [])
-        |> Keyword.get(key, default)
-
-      value ->
-        value
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -61,6 +61,7 @@ defmodule LlmComposer.MixProject do
       ],
       source_url: "https://github.com/doofinder/llm_composer",
       test_coverage: [tool: ExCoveralls],
+      dialyzer: [plt_add_apps: [:credo]],
       aliases: aliases()
     ]
   end


### PR DESCRIPTION
## Summary

- Adds a custom Credo check (`LlmComposer.CredoChecks.GroupedFunctions`) that enforces `def` and `defp` clauses are not interleaved — all public functions must be grouped together and all private functions grouped together within a module
- Enables the check in `.credo.exs`
- Refactors three existing modules to comply: `FunctionCallExtractors`, `Helpers`, and `Providers.Utils` (private functions moved to the bottom, no logic changes)

## Test plan
- [x] `mix precommit` passes (no credo issues, all tests green)
- [x] Verify the check catches interleaved functions if you manually reorder one