### PR TITLE
Add LlmComposer.Tool: @tool attribute DSL for defining agent tools

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -41,7 +41,9 @@
       # If you create your own checks, you must specify the source files for
       # them here, so they can be loaded by Credo before running the analysis.
       #
-      requires: [],
+      requires: [
+        "./lib/llm_composer/credo_checks/grouped_functions.ex"
+      ],
       #
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:
@@ -101,6 +103,7 @@
           {Credo.Check.Readability.ModuleAttributeNames, []},
           {Credo.Check.Readability.ModuleDoc, []},
           {Credo.Check.Readability.ModuleNames, []},
+          {LlmComposer.CredoChecks.GroupedFunctions, []},
           {Credo.Check.Readability.ParenthesesInCondition, []},
           {Credo.Check.Readability.ParenthesesOnZeroArityDefs, []},
           {Credo.Check.Readability.PipeIntoAnonymousFunctions, []},

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,9 @@ The project follows a modular organization separating core functionality, provid
 ```
 lib
 ├── llm_composer
+│   ├── agent
+│   │   └── result.ex
+│   ├── agent.ex
 │   ├── cache
 │   │   ├── behaviour.ex
 │   │   └── ets.ex
@@ -106,6 +109,7 @@ lib
 └── llm_composer.ex
 test
 ├── llm_composer
+│   ├── agent_test.exs         # LlmComposer.Agent tool-calling loop tests
 │   ├── cost/                  # cost_assembler, cost_info, pricing tests
 │   ├── providers/             # per-provider tests (bedrock, google, ollama, open_ai, open_router, utils)
 │   ├── http_client_test.exs

--- a/guides/agent.md
+++ b/guides/agent.md
@@ -1,0 +1,120 @@
+# Agent Loop
+
+`LlmComposer.Agent` runs an **automatic tool-calling loop** on top of
+`LlmComposer.run_completion/3`. Where `simple_chat/2` and `run_completion/3` perform a single model
+turn — leaving you to execute any requested tool calls and re-prompt manually (see the
+[Function Calls guide](function_calls.md)) — the agent automates the whole cycle:
+
+```
+ask → model requests tool calls → execute them → feed the results back → repeat
+      → until the model returns a final, tool-free answer
+```
+
+The loop is **synchronous** (streaming is not supported in this version) and pure orchestration
+over existing building blocks, so it works with any provider that supports function calling
+(**OpenAI**, **OpenRouter**, **Google**).
+
+## Quick start
+
+```elixir
+defmodule MyTools do
+  @spec calculator(map()) :: number()
+  def calculator(%{"expression" => expression}) do
+    {result, _binding} = Code.eval_string(expression)
+    result
+  end
+end
+
+calculator = %LlmComposer.Function{
+  mf: {MyTools, :calculator},
+  name: "calculator",
+  description: "Evaluates a math expression",
+  schema: %{
+    "type" => "object",
+    "properties" => %{"expression" => %{"type" => "string"}},
+    "required" => ["expression"]
+  }
+}
+
+settings = %LlmComposer.Settings{
+  providers: [
+    {LlmComposer.Providers.OpenAI, [model: "gpt-4.1-mini", functions: [calculator]]}
+  ],
+  system_prompt: "You are a helpful assistant.",
+  api_key: "<your api key>",
+  track_costs: true
+}
+
+{:ok, result} = LlmComposer.Agent.run(settings, "How much is (2 + 3) * 4?")
+
+IO.puts(result.response.main_response.content)
+# => "The result is 20."
+IO.inspect(result.iterations)
+# => 2
+```
+
+The `:functions` available to the model are read from the provider options in `settings` by
+default, so you normally do not pass them again to `run/3`.
+
+## Input
+
+`run/3` accepts either:
+
+- a **prompt string** — wrapped into a `:user` message (honouring the settings'
+  `:user_prompt_prefix`), or
+- an explicit **list of `LlmComposer.Message.t()`** — useful to continue an existing conversation.
+
+## The result
+
+A successful run returns `{:ok, %LlmComposer.Agent.Result{}}`:
+
+| Field | Description |
+|---|---|
+| `:response` | The final `LlmComposer.LlmResponse.t()` (tool-free assistant answer). |
+| `:messages` | The full conversation, including assistant tool-call messages and `:tool_result` messages. Ready to persist or continue. |
+| `:iterations` | Number of model turns performed. |
+| `:cost_infos` | List of `LlmComposer.CostInfo.t()`, one per turn that reported costs (requires `track_costs: true`). |
+| `:function_calls` | Every executed `LlmComposer.FunctionCall.t()`, in order, each carrying its `:result`. |
+
+## Options
+
+| Option | Default | Description |
+|---|---|---|
+| `:max_iterations` | `10` | Maximum model turns before giving up. Exceeding it returns `{:error, :max_iterations_reached}`. |
+| `:functions` | from settings | Tools available to the model. |
+| `:tool_execution` | `:sequential` | `:sequential` runs tool calls one by one; `:parallel` runs them concurrently (`Task.async_stream/3`) while preserving result order. |
+| `:tool_timeout` | `:infinity` | Per-task timeout (ms or `:infinity`) used in `:parallel` mode. |
+
+## Error handling
+
+- **Tool errors** (unknown tool, invalid arguments, exception during execution) do **not** abort the
+  loop. The error is formatted as an `"Error: ..."` string and fed back to the model as the tool
+  result, giving it a chance to recover or explain the failure.
+- **Model/network errors** returned by the provider abort the loop and are returned as
+  `{:error, reason}`.
+- **Streaming** settings (`stream_response: true`) return `{:error, :streaming_not_supported}`.
+
+## Telemetry
+
+The loop emits `:telemetry` events you can attach handlers to:
+
+| Event | Measurements | Metadata |
+|---|---|---|
+| `[:llm_composer, :agent, :run, :start \| :stop \| :exception]` | `:iterations` (on stop), `:duration` | `:status` (`:ok`/`:error`), `:reason`, `:max_iterations`, `:tool_count` |
+| `[:llm_composer, :agent, :iteration, :stop]` | `:tool_call_count` | `:iteration`, `:cost_info`, `:final` |
+| `[:llm_composer, :agent, :tool, :start \| :stop \| :exception]` | `:duration` | `:name`, `:status` (`:ok`/`:error`) |
+
+The per-iteration event carries that turn's `:cost_info`, so you can record costs incrementally as
+each completion finishes rather than only at the end of the run.
+
+```elixir
+:telemetry.attach(
+  "agent-costs",
+  [:llm_composer, :agent, :iteration, :stop],
+  fn _event, _measurements, %{cost_info: cost_info}, _config ->
+    # persist or report cost_info for this completion
+    MyApp.Usage.record(cost_info)
+  end,
+  nil
+)
+```

--- a/guides/function_calls.md
+++ b/guides/function_calls.md
@@ -11,6 +11,10 @@ automatic execution — useful when you need to:
 
 Supported providers: **OpenAI**, **OpenRouter**, **Google**.
 
+> **Looking for automatic looping?** If you just want the model to call tools, get their results,
+> and continue until it produces a final answer, use `LlmComposer.Agent` — it automates the
+> manual workflow below. See the [Agent guide](agent.md).
+
 ## The 3-Step Workflow
 
 ```elixir

--- a/lib/llm_composer.ex
+++ b/lib/llm_composer.ex
@@ -85,19 +85,18 @@ defmodule LlmComposer do
   def run_completion(settings, messages, previous_response \\ nil) do
     system_msg = Message.new(:system, settings.system_prompt)
 
-    messages
-    |> ProvidersRunner.run(settings, system_msg)
-    |> then(fn
-      {:ok, %LlmResponse{} = res} ->
-        # set previous response all the time
-        res = %LlmResponse{res | previous_response: previous_response}
+    :telemetry.span([:llm_composer, :run_completion], %{}, fn ->
+      case ProvidersRunner.run(messages, settings, system_msg) do
+        {:ok, %LlmResponse{} = res} ->
+          res = %LlmResponse{res | previous_response: previous_response}
+          Logger.debug("input_tokens=#{res.input_tokens}, output_tokens=#{res.output_tokens}")
 
-        Logger.debug("input_tokens=#{res.input_tokens}, output_tokens=#{res.output_tokens}")
+          {{:ok, res}, %{input_tokens: res.input_tokens, output_tokens: res.output_tokens},
+           %{status: :ok}}
 
-        {:ok, res}
-
-      {:error, _data} = resp ->
-        resp
+        {:error, _} = err ->
+          {err, %{input_tokens: 0, output_tokens: 0}, %{status: :error}}
+      end
     end)
   end
 

--- a/lib/llm_composer/agent.ex
+++ b/lib/llm_composer/agent.ex
@@ -1,0 +1,366 @@
+defmodule LlmComposer.Agent do
+  @moduledoc """
+  Runs an agentic tool-calling loop on top of `LlmComposer.run_completion/3`.
+
+  Where `LlmComposer.simple_chat/2` and `LlmComposer.run_completion/3` perform a single model
+  turn, `LlmComposer.Agent.run/3` automates the full cycle:
+
+      ask → model requests tool calls → execute them → feed the results back → repeat
+            → until the model returns a final, tool-free answer.
+
+  The loop is pure orchestration over existing building blocks
+  (`LlmComposer.FunctionExecutor`, `LlmComposer.FunctionCallHelpers`) and does not change any
+  provider behaviour. It is **synchronous** — streaming is not supported in this version.
+
+  ## Example
+
+      defmodule MyTools do
+        def calculator(%{"expression" => expression}) do
+          {result, _binding} = Code.eval_string(expression)
+          result
+        end
+      end
+
+      calculator = %LlmComposer.Function{
+        mf: {MyTools, :calculator},
+        name: "calculator",
+        description: "Evaluates a math expression",
+        schema: %{
+          "type" => "object",
+          "properties" => %{"expression" => %{"type" => "string"}},
+          "required" => ["expression"]
+        }
+      }
+
+      settings = %LlmComposer.Settings{
+        providers: [{LlmComposer.Providers.OpenAI, [model: "gpt-4.1-mini", functions: [calculator]]}],
+        system_prompt: "You are a helpful assistant.",
+        api_key: "sk-...",
+        track_costs: true
+      }
+
+      {:ok, result} = LlmComposer.Agent.run(settings, "How much is (2 + 3) * 4?")
+
+      result.response.main_response.content
+      # => "The result is 20."
+      result.iterations
+      # => 2
+
+  ## Options
+
+  - `:max_iterations` — maximum number of model turns before giving up. Defaults to `10`. When
+    exceeded while the model still wants to call tools, `run/3` returns
+    `{:error, :max_iterations_reached}`.
+  - `:functions` — list of `LlmComposer.Function.t()` available to the model. Defaults to the
+    `:functions` configured in the settings' provider options, so you usually do not need to set
+    this explicitly.
+  - `:tool_execution` — `:sequential` (default) runs tool calls one by one; `:parallel` runs them
+    concurrently with `Task.async_stream/3` while preserving result order.
+  - `:tool_timeout` — per-task timeout (ms or `:infinity`) used in `:parallel` mode. Defaults to
+    `:infinity`.
+
+  ## Tool errors
+
+  When a tool call fails (`:function_not_found`, invalid arguments, or an exception during
+  execution) the loop does **not** abort. Instead it feeds an `"Error: ..."` string back to the
+  model as the tool result, giving the model a chance to recover or explain the failure. A model
+  or network error returned by the provider, by contrast, aborts the loop and is returned as
+  `{:error, reason}`.
+
+  ## Telemetry
+
+  The loop emits the following `:telemetry` events:
+
+  - `[:llm_composer, :agent, :run, :start | :stop | :exception]` — the whole run. The `:stop`
+    event includes an `:iterations` measurement and a `:status` (`:ok`/`:error`) metadata key.
+  - `[:llm_composer, :agent, :iteration, :stop]` — one per model turn. Measurement
+    `:tool_call_count`; metadata `:iteration`, `:cost_info`, `:final`.
+  - `[:llm_composer, :agent, :tool, :start | :stop | :exception]` — one per tool execution.
+    Metadata `:name` and (on stop) `:status` (`:ok`/`:error`).
+  """
+
+  alias LlmComposer.Agent.Result
+  alias LlmComposer.CostInfo
+  alias LlmComposer.Function
+  alias LlmComposer.FunctionCall
+  alias LlmComposer.FunctionCallHelpers
+  alias LlmComposer.FunctionExecutor
+  alias LlmComposer.LlmResponse
+  alias LlmComposer.Message
+  alias LlmComposer.Settings
+
+  require Logger
+
+  @default_max_iterations 10
+
+  @type input() :: String.t() | [Message.t()]
+
+  @type run_opts() :: [
+          max_iterations: pos_integer(),
+          functions: [Function.t()],
+          tool_execution: :sequential | :parallel,
+          tool_timeout: timeout()
+        ]
+
+  @typep config() :: %{
+           settings: Settings.t(),
+           functions: [Function.t()],
+           max_iterations: pos_integer(),
+           tool_execution: :sequential | :parallel,
+           tool_timeout: timeout()
+         }
+
+  @typep acc() :: %{cost_infos: [CostInfo.t()], function_calls: [FunctionCall.t()]}
+
+  @doc """
+  Runs the agentic tool-calling loop until the model returns a final, tool-free response.
+
+  Accepts either a user prompt string (wrapped into a `:user` message, honouring the settings'
+  `:user_prompt_prefix`) or an explicit list of `LlmComposer.Message.t()`.
+
+  Returns `{:ok, %LlmComposer.Agent.Result{}}` on success, or `{:error, reason}` where `reason`
+  may be `:max_iterations_reached`, `:streaming_not_supported`, or any error returned by the
+  underlying provider.
+
+  See the module documentation for the available options.
+  """
+  @spec run(Settings.t(), input(), run_opts()) :: {:ok, Result.t()} | {:error, term()}
+  def run(settings, input, opts \\ [])
+
+  def run(%Settings{stream_response: true}, _input, _opts), do: {:error, :streaming_not_supported}
+
+  def run(%Settings{} = settings, input, opts) do
+    functions = Keyword.get(opts, :functions) || functions_from_settings(settings)
+    max_iterations = Keyword.get(opts, :max_iterations, @default_max_iterations)
+
+    config = %{
+      settings: settings,
+      functions: functions,
+      max_iterations: max_iterations,
+      tool_execution: Keyword.get(opts, :tool_execution, :sequential),
+      tool_timeout: Keyword.get(opts, :tool_timeout, :infinity)
+    }
+
+    messages = normalize_input(settings, input)
+    start_metadata = %{max_iterations: max_iterations, tool_count: length(functions)}
+
+    :telemetry.span([:llm_composer, :agent, :run], start_metadata, fn ->
+      result = loop(config, messages, 0, new_acc())
+      {result, run_measurements(result), run_stop_metadata(start_metadata, result)}
+    end)
+  end
+
+  # --- Loop ---
+
+  @spec loop(config(), [Message.t()], non_neg_integer(), acc()) ::
+          {:ok, Result.t()} | {:error, term()}
+  defp loop(%{max_iterations: max}, _messages, iteration, _acc) when iteration >= max do
+    {:error, :max_iterations_reached}
+  end
+
+  defp loop(config, messages, iteration, acc) do
+    case LlmComposer.run_completion(config.settings, messages) do
+      {:ok, %LlmResponse{stream: nil} = response} ->
+        handle_response(config, messages, iteration, acc, response)
+
+      {:ok, %LlmResponse{}} ->
+        {:error, :streaming_not_supported}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @spec handle_response(config(), [Message.t()], non_neg_integer(), acc(), LlmResponse.t()) ::
+          {:ok, Result.t()} | {:error, term()}
+  defp handle_response(config, messages, iteration, acc, response) do
+    next_iteration = iteration + 1
+    cost_infos = acc.cost_infos ++ List.wrap(response.cost_info)
+
+    case LlmResponse.function_calls(response) do
+      calls when calls in [nil, []] ->
+        emit_iteration(next_iteration, response.cost_info, 0, true)
+        finalize(response, messages, next_iteration, %{acc | cost_infos: cost_infos})
+
+      calls ->
+        executed = execute_tool_calls(config, calls)
+        emit_iteration(next_iteration, response.cost_info, length(calls), false)
+
+        provider_mod = resolve_provider_module(config.settings, response.provider)
+        provider_opts = provider_opts_for(config.settings, provider_mod)
+
+        assistant_msg =
+          FunctionCallHelpers.build_assistant_with_tools(
+            provider_mod,
+            response,
+            last_user_message(messages),
+            provider_opts
+          )
+
+        tool_msgs = FunctionCallHelpers.build_tool_result_messages(executed)
+
+        loop(
+          config,
+          messages ++ [assistant_msg | tool_msgs],
+          next_iteration,
+          %{acc | cost_infos: cost_infos, function_calls: acc.function_calls ++ executed}
+        )
+    end
+  end
+
+  @spec finalize(LlmResponse.t(), [Message.t()], non_neg_integer(), acc()) :: {:ok, Result.t()}
+  defp finalize(response, messages, iterations, acc) do
+    {:ok,
+     %Result{
+       response: response,
+       messages: messages ++ [response.main_response],
+       iterations: iterations,
+       cost_infos: acc.cost_infos,
+       function_calls: acc.function_calls
+     }}
+  end
+
+  # --- Tool execution ---
+
+  @spec execute_tool_calls(config(), [FunctionCall.t()]) :: [FunctionCall.t()]
+  defp execute_tool_calls(%{tool_execution: :parallel} = config, calls) do
+    calls
+    |> Task.async_stream(&execute_one(config, &1),
+      ordered: true,
+      timeout: config.tool_timeout,
+      on_timeout: :kill_task
+    )
+    |> Enum.zip(calls)
+    |> Enum.map(fn
+      {{:ok, executed}, _call} -> executed
+      {{:exit, reason}, call} -> error_call(call, {:execution_failed, inspect(reason)})
+    end)
+  end
+
+  defp execute_tool_calls(config, calls) do
+    Enum.map(calls, &execute_one(config, &1))
+  end
+
+  @spec execute_one(config(), FunctionCall.t()) :: FunctionCall.t()
+  defp execute_one(config, %FunctionCall{} = call) do
+    :telemetry.span([:llm_composer, :agent, :tool], %{name: call.name}, fn ->
+      {executed, status} =
+        case FunctionExecutor.execute(call, config.functions) do
+          {:ok, executed} ->
+            {executed, :ok}
+
+          {:error, reason} ->
+            Logger.warning(
+              "[llm_composer.agent] tool_error name=#{call.name} reason=#{inspect(reason)}"
+            )
+
+            {error_call(call, reason), :error}
+        end
+
+      {executed, %{name: call.name, status: status}}
+    end)
+  end
+
+  @spec error_call(FunctionCall.t(), term()) :: FunctionCall.t()
+  defp error_call(%FunctionCall{} = call, reason) do
+    %FunctionCall{call | result: "Error: #{format_tool_error(reason)}"}
+  end
+
+  @spec format_tool_error(
+          :function_not_found
+          | {:execution_failed, String.t()}
+          | {:invalid_arguments, String.t()}
+        ) ::
+          String.t()
+  defp format_tool_error({:invalid_arguments, reason}), do: "invalid arguments (#{reason})"
+  defp format_tool_error({:execution_failed, reason}), do: "execution failed (#{reason})"
+  defp format_tool_error(:function_not_found), do: "unknown tool"
+
+  # --- Telemetry helpers ---
+
+  @spec emit_iteration(non_neg_integer(), CostInfo.t() | nil, non_neg_integer(), boolean()) :: :ok
+  defp emit_iteration(iteration, cost_info, tool_call_count, final?) do
+    :telemetry.execute(
+      [:llm_composer, :agent, :iteration, :stop],
+      %{tool_call_count: tool_call_count},
+      %{iteration: iteration, cost_info: cost_info, final: final?}
+    )
+  end
+
+  @spec run_measurements({:ok, Result.t()} | {:error, term()}) :: map()
+  defp run_measurements({:ok, %Result{iterations: iterations}}), do: %{iterations: iterations}
+  defp run_measurements({:error, _reason}), do: %{iterations: 0}
+
+  @spec run_stop_metadata(map(), {:ok, Result.t()} | {:error, term()}) :: map()
+  defp run_stop_metadata(metadata, {:ok, _result}), do: Map.put(metadata, :status, :ok)
+
+  defp run_stop_metadata(metadata, {:error, reason}) do
+    Map.merge(metadata, %{status: :error, reason: reason})
+  end
+
+  # --- Settings / message helpers ---
+
+  @spec normalize_input(Settings.t(), input()) :: [Message.t()]
+  defp normalize_input(settings, prompt) when is_binary(prompt) do
+    [Message.new(:user, user_prompt(settings, prompt))]
+  end
+
+  defp normalize_input(_settings, messages) when is_list(messages), do: messages
+
+  @spec user_prompt(Settings.t(), String.t()) :: String.t()
+  defp user_prompt(%Settings{user_prompt_prefix: prefix}, message) when is_binary(prefix) do
+    prefix <> message
+  end
+
+  defp user_prompt(_settings, message), do: message
+
+  @spec functions_from_settings(Settings.t()) :: [Function.t()]
+  defp functions_from_settings(%Settings{providers: [{_mod, opts} | _]}) when is_list(opts) do
+    Keyword.get(opts, :functions, [])
+  end
+
+  defp functions_from_settings(%Settings{provider_opts: opts}) when is_list(opts) do
+    Keyword.get(opts, :functions, [])
+  end
+
+  defp functions_from_settings(_settings), do: []
+
+  @spec resolve_provider_module(Settings.t(), atom()) :: module() | nil
+  defp resolve_provider_module(settings, provider_atom) do
+    settings
+    |> configured_providers()
+    |> Enum.find_value(fn {mod, _opts} ->
+      if function_exported?(mod, :name, 0) and mod.name() == provider_atom, do: mod
+    end)
+  end
+
+  @spec provider_opts_for(Settings.t(), module() | nil) :: keyword()
+  defp provider_opts_for(settings, provider_mod) do
+    settings
+    |> configured_providers()
+    |> Enum.find_value([], fn
+      {^provider_mod, opts} -> opts || []
+      _entry -> false
+    end)
+  end
+
+  @spec configured_providers(Settings.t()) :: [{module(), keyword()}]
+  defp configured_providers(%Settings{providers: providers}) when is_list(providers),
+    do: providers
+
+  defp configured_providers(%Settings{provider: nil}), do: []
+
+  defp configured_providers(%Settings{provider: mod, provider_opts: opts}),
+    do: [{mod, opts || []}]
+
+  @spec last_user_message([Message.t()]) :: Message.t()
+  defp last_user_message(messages) do
+    Enum.reduce(messages, %Message{type: :user, content: ""}, fn
+      %Message{type: :user} = msg, _acc -> msg
+      _msg, acc -> acc
+    end)
+  end
+
+  @spec new_acc() :: acc()
+  defp new_acc, do: %{cost_infos: [], function_calls: []}
+end

--- a/lib/llm_composer/agent/result.ex
+++ b/lib/llm_composer/agent/result.ex
@@ -1,0 +1,44 @@
+defmodule LlmComposer.Agent.Result do
+  @moduledoc """
+  Result of a completed `LlmComposer.Agent` run.
+
+  Returned as `{:ok, %LlmComposer.Agent.Result{}}` by `LlmComposer.Agent.run/3` when the loop
+  reaches a final, tool-free assistant response. It bundles the final response together with the
+  full conversation, the executed tool calls, and accumulated cost information so callers can
+  inspect, persist, or display the entire run.
+
+  ## Fields
+
+  - `:response` — the final `LlmComposer.LlmResponse.t()` (the tool-free assistant answer).
+  - `:messages` — the full conversation, including the user message(s), assistant tool-call
+    messages and `:tool_result` messages appended on each iteration. Suitable for persistence or
+    for continuing the conversation.
+  - `:iterations` — number of model turns performed (each call to the provider counts as one).
+  - `:cost_infos` — list of `LlmComposer.CostInfo.t()`, one per model turn that reported cost
+    information, in turn order (turns without cost info are omitted). Requires `track_costs: true`
+    in settings. Each entry is also emitted on the per-iteration telemetry event, so callers can
+    record costs incrementally rather than only at the end of the run.
+  - `:function_calls` — every executed `LlmComposer.FunctionCall.t()` across all iterations, in
+    execution order, each carrying its `:result`.
+  """
+
+  alias LlmComposer.CostInfo
+  alias LlmComposer.FunctionCall
+  alias LlmComposer.LlmResponse
+  alias LlmComposer.Message
+
+  @type t() :: %__MODULE__{
+          response: LlmResponse.t(),
+          messages: [Message.t()],
+          iterations: non_neg_integer(),
+          cost_infos: [CostInfo.t()],
+          function_calls: [FunctionCall.t()]
+        }
+
+  @enforce_keys [:response, :messages, :iterations]
+  defstruct response: nil,
+            messages: [],
+            iterations: 0,
+            cost_infos: [],
+            function_calls: []
+end

--- a/lib/llm_composer/credo_checks/grouped_functions.ex
+++ b/lib/llm_composer/credo_checks/grouped_functions.ex
@@ -1,0 +1,84 @@
+if Code.ensure_loaded?(Credo.Check) do
+  defmodule LlmComposer.CredoChecks.GroupedFunctions do
+    @moduledoc false
+
+    use Credo.Check,
+      base_priority: :normal,
+      category: :readability,
+      explanations: [
+        check: """
+        Public and private functions must be grouped, not interleaved.
+        Keep all `def` clauses together and all `defp` clauses together.
+        """
+      ]
+
+    alias Credo.IssueMeta
+    alias Credo.SourceFile
+
+    @impl Credo.Check
+    def run(%SourceFile{} = source_file, params) do
+      issue_meta = IssueMeta.for(source_file, params)
+
+      source_file
+      |> Credo.Code.prewalk(&traverse(&1, &2), [])
+      |> check_grouping(issue_meta)
+    end
+
+    defp traverse({kind, meta, [head | _]} = ast, acc) when kind in [:def, :defp] do
+      name = extract_name(head)
+      visibility = if kind == :def, do: :public, else: :private
+      {ast, [{visibility, name, meta[:line]} | acc]}
+    end
+
+    defp traverse(ast, acc), do: {ast, acc}
+
+    defp extract_name({:when, _, [head | _]}), do: extract_name(head)
+    defp extract_name({name, _, _}) when is_atom(name), do: name
+    defp extract_name(_), do: :unknown
+
+    defp check_grouping(collected, issue_meta) do
+      functions =
+        collected
+        |> Enum.reverse()
+        |> Enum.dedup_by(fn {visibility, name, _line} -> {visibility, name} end)
+
+      blocks = Enum.chunk_by(functions, fn {visibility, _, _} -> visibility end)
+
+      duplicated_visibilities =
+        blocks
+        |> Enum.map(fn [{visibility, _, _} | _] -> visibility end)
+        |> Enum.frequencies()
+        |> Enum.filter(fn {_visibility, count} -> count > 1 end)
+        |> Enum.map(fn {visibility, _} -> visibility end)
+
+      blocks
+      |> mark_offending_blocks(duplicated_visibilities)
+      |> Enum.map(fn {visibility, name, line} ->
+        build_issue(visibility, name, line, issue_meta)
+      end)
+    end
+
+    defp mark_offending_blocks(blocks, duplicated_visibilities) do
+      {offending, _seen} =
+        Enum.reduce(blocks, {[], MapSet.new()}, fn [{visibility, name, line} | _], {acc, seen} ->
+          if visibility in duplicated_visibilities and MapSet.member?(seen, visibility) do
+            {[{visibility, name, line} | acc], seen}
+          else
+            {acc, MapSet.put(seen, visibility)}
+          end
+        end)
+
+      Enum.reverse(offending)
+    end
+
+    defp build_issue(visibility, name, line_no, issue_meta) do
+      format_issue(
+        issue_meta,
+        message:
+          "#{visibility} function `#{name}` breaks grouping; keep all public and private functions grouped.",
+        trigger: to_string(name),
+        line_no: line_no
+      )
+    end
+  end
+end

--- a/lib/llm_composer/function_call_extractors.ex
+++ b/lib/llm_composer/function_call_extractors.ex
@@ -11,19 +11,6 @@ defmodule LlmComposer.FunctionCallExtractors do
 
   def from_tool_calls(_), do: nil
 
-  defp build_tool_call(tool_call) do
-    function_info = tool_call["function"]
-
-    %FunctionCall{
-      id: tool_call["id"],
-      name: function_info["name"],
-      arguments: function_info["arguments"],
-      type: tool_call["type"],
-      metadata: %{},
-      result: nil
-    }
-  end
-
   @spec from_google_parts(map()) :: [FunctionCall.t()] | nil
   def from_google_parts(%{"parts" => parts}) when is_list(parts) do
     function_calls =
@@ -73,4 +60,17 @@ defmodule LlmComposer.FunctionCallExtractors do
   end
 
   def from_bedrock_content(_), do: nil
+
+  defp build_tool_call(tool_call) do
+    function_info = tool_call["function"]
+
+    %FunctionCall{
+      id: tool_call["id"],
+      name: function_info["name"],
+      arguments: function_info["arguments"],
+      type: tool_call["type"],
+      metadata: %{},
+      result: nil
+    }
+  end
 end

--- a/lib/llm_composer/helpers.ex
+++ b/lib/llm_composer/helpers.ex
@@ -28,14 +28,6 @@ defmodule LlmComposer.Helpers do
 
   def normalize_json(data), do: data
 
-  defp ordered_object?(data) do
-    data != [] and
-      Enum.all?(data, fn
-        {key, _value} when is_binary(key) or is_atom(key) -> true
-        _other -> false
-      end)
-  end
-
   @doc """
   Returns the configured JSON engine module.
 
@@ -48,6 +40,14 @@ defmodule LlmComposer.Helpers do
       nil -> if Code.ensure_loaded?(JSON), do: JSON, else: Jason
       engine -> engine
     end
+  end
+
+  defp ordered_object?(data) do
+    data != [] and
+      Enum.all?(data, fn
+        {key, _value} when is_binary(key) or is_atom(key) -> true
+        _other -> false
+      end)
   end
 
   defp normalize_key(key) when is_binary(key), do: key

--- a/lib/llm_composer/provider_router/simple.ex
+++ b/lib/llm_composer/provider_router/simple.ex
@@ -96,6 +96,13 @@ defmodule LlmComposer.ProviderRouter.Simple do
         # Provider was blocked, so unblock it and log
         cache_mod().delete(provider, name)
         Logger.info("[#{provider.name()}] unblocked after success")
+
+        :telemetry.execute(
+          [:llm_composer, :provider_router, :unblocked],
+          %{},
+          %{provider: provider.name()}
+        )
+
         :ok
     end
   end
@@ -129,6 +136,12 @@ defmodule LlmComposer.ProviderRouter.Simple do
 
     Logger.info(
       "[#{provider.name()}] blocked for #{backoff_ms} ms due to error #{inspect(error)}"
+    )
+
+    :telemetry.execute(
+      [:llm_composer, :provider_router, :blocked],
+      %{backoff_ms: backoff_ms, failure_count: failure_count},
+      %{provider: provider.name()}
     )
 
     :block

--- a/lib/llm_composer/providers/utils.ex
+++ b/lib/llm_composer/providers/utils.ex
@@ -108,6 +108,85 @@ defmodule LlmComposer.Providers.Utils do
     |> merge_consecutive_function_responses()
   end
 
+  @spec cleanup_body(map()) :: map()
+  def cleanup_body(body) do
+    body
+    |> Enum.reject(fn
+      {_param, nil} -> true
+      {_param, []} -> true
+      _other -> false
+    end)
+    |> Map.new()
+  end
+
+  @spec merge_request_params(map(), map()) :: map()
+  def merge_request_params(base_req, req_params) do
+    Enum.reduce(req_params, base_req, fn {key, value}, acc ->
+      existing = Map.get(acc, key)
+
+      if is_map(existing) and is_map(value) do
+        Map.put(acc, key, Map.merge(existing, value))
+      else
+        Map.put(acc, key, value)
+      end
+    end)
+  end
+
+  @spec get_tools([LlmComposer.Function.t()] | nil, atom) :: nil | [map()]
+  def get_tools(nil, _provider), do: nil
+
+  def get_tools(functions, provider) when is_list(functions) do
+    Enum.map(functions, &transform_fn_to_tool(&1, provider))
+  end
+
+  @spec get_req_opts(keyword()) :: keyword()
+  def get_req_opts(opts) do
+    if Keyword.get(opts, :stream_response) do
+      [adapter: stream_adapter_opts()]
+    else
+      []
+    end
+  end
+
+  @doc """
+  Reads a configuration value for the given provider key.
+
+  Priority order:
+  1. Get from `opts` keyword list.
+  2. Get from application config `:llm_composer`, provider_key.
+  3. Use provided `default` value.
+  """
+  @spec get_open_ai_key(keyword()) :: String.t()
+  def get_open_ai_key(opts) do
+    case get_config(:open_ai, :api_key, opts) do
+      nil -> raise LlmComposer.Errors.MissingKeyError
+      key -> key
+    end
+  end
+
+  @spec get_open_ai_request_opts(keyword()) :: keyword()
+  def get_open_ai_request_opts(opts) do
+    timeout = Keyword.get(opts, :timeout, Application.get_env(:llm_composer, :timeout, 50_000))
+    adapter_opts = [receive_timeout: timeout]
+
+    opts
+    |> get_req_opts()
+    |> Keyword.update(:adapter, adapter_opts, &Keyword.merge(&1, adapter_opts))
+  end
+
+  @spec get_config(atom, atom, keyword, any) :: any
+  def get_config(provider_key, key, opts, default \\ nil) do
+    case Keyword.get(opts, key) do
+      nil ->
+        :llm_composer
+        |> Application.get_env(provider_key, [])
+        |> Keyword.get(key, default)
+
+      value ->
+        value
+    end
+  end
+
   @spec build_google_assistant_message(
           String.t() | nil,
           [LlmComposer.FunctionCall.t()] | nil,
@@ -175,46 +254,6 @@ defmodule LlmComposer.Providers.Utils do
     |> Enum.reverse()
   end
 
-  @spec cleanup_body(map()) :: map()
-  def cleanup_body(body) do
-    body
-    |> Enum.reject(fn
-      {_param, nil} -> true
-      {_param, []} -> true
-      _other -> false
-    end)
-    |> Map.new()
-  end
-
-  @spec merge_request_params(map(), map()) :: map()
-  def merge_request_params(base_req, req_params) do
-    Enum.reduce(req_params, base_req, fn {key, value}, acc ->
-      existing = Map.get(acc, key)
-
-      if is_map(existing) and is_map(value) do
-        Map.put(acc, key, Map.merge(existing, value))
-      else
-        Map.put(acc, key, value)
-      end
-    end)
-  end
-
-  @spec get_tools([LlmComposer.Function.t()] | nil, atom) :: nil | [map()]
-  def get_tools(nil, _provider), do: nil
-
-  def get_tools(functions, provider) when is_list(functions) do
-    Enum.map(functions, &transform_fn_to_tool(&1, provider))
-  end
-
-  @spec get_req_opts(keyword()) :: keyword()
-  def get_req_opts(opts) do
-    if Keyword.get(opts, :stream_response) do
-      [adapter: stream_adapter_opts()]
-    else
-      []
-    end
-  end
-
   defp stream_adapter_opts do
     case Application.get_env(:llm_composer, :tesla_adapter, Tesla.Adapter.Mint) do
       {Tesla.Adapter.Finch, _opts} -> [response: :stream]
@@ -222,45 +261,6 @@ defmodule LlmComposer.Providers.Utils do
       {Tesla.Adapter.Mint, _opts} -> [body_as: :stream]
       Tesla.Adapter.Mint -> [body_as: :stream]
       _other -> [response: :stream]
-    end
-  end
-
-  @doc """
-  Reads a configuration value for the given provider key.
-
-  Priority order:
-  1. Get from `opts` keyword list.
-  2. Get from application config `:llm_composer`, provider_key.
-  3. Use provided `default` value.
-  """
-  @spec get_open_ai_key(keyword()) :: String.t()
-  def get_open_ai_key(opts) do
-    case get_config(:open_ai, :api_key, opts) do
-      nil -> raise LlmComposer.Errors.MissingKeyError
-      key -> key
-    end
-  end
-
-  @spec get_open_ai_request_opts(keyword()) :: keyword()
-  def get_open_ai_request_opts(opts) do
-    timeout = Keyword.get(opts, :timeout, Application.get_env(:llm_composer, :timeout, 50_000))
-    adapter_opts = [receive_timeout: timeout]
-
-    opts
-    |> get_req_opts()
-    |> Keyword.update(:adapter, adapter_opts, &Keyword.merge(&1, adapter_opts))
-  end
-
-  @spec get_config(atom, atom, keyword, any) :: any
-  def get_config(provider_key, key, opts, default \\ nil) do
-    case Keyword.get(opts, key) do
-      nil ->
-        :llm_composer
-        |> Application.get_env(provider_key, [])
-        |> Keyword.get(key, default)
-
-      value ->
-        value
     end
   end
 

--- a/lib/llm_composer/providers_runner.ex
+++ b/lib/llm_composer/providers_runner.ex
@@ -4,7 +4,6 @@ defmodule LlmComposer.ProvidersRunner do
   and error handling for multiple provider configurations.
   """
 
-  alias LlmComposer.LlmResponse
   alias LlmComposer.Message
   alias LlmComposer.Settings
 
@@ -44,16 +43,9 @@ defmodule LlmComposer.ProvidersRunner do
     case router.select_provider(all_providers) do
       {:ok, {selected_provider, provider_opts}} ->
         provider_opts = get_provider_opts(provider_opts, settings)
+        result = run_provider(selected_provider, messages, system_msg, provider_opts)
 
-        {exec_time_us, result} =
-          :timer.tc(fn ->
-            selected_provider.run(messages, system_msg, provider_opts)
-          end)
-
-        metrics = build_metrics(result, exec_time_us, selected_provider, provider_opts)
-        Logger.debug("#{selected_provider.name()} metrics: #{inspect(metrics)}")
-
-        case handle_provider_result(result, selected_provider, router, metrics) do
+        case handle_provider_result(result, selected_provider, router) do
           {:halt, ok_res} ->
             ok_res
 
@@ -69,22 +61,34 @@ defmodule LlmComposer.ProvidersRunner do
   @spec handle_provider_result(
           {:ok, map()} | {:error, any()},
           module(),
-          module(),
-          map()
+          module()
         ) :: {:cont, {:error, any()}} | {:halt, {:ok, any()}}
-  defp handle_provider_result({:ok, _res} = ok_res, provider, router, metrics) do
-    router.on_provider_success(provider, ok_res, metrics)
+  defp handle_provider_result({:ok, _res} = ok_res, provider, router) do
+    router.on_provider_success(provider, ok_res, %{})
     {:halt, ok_res}
   end
 
-  defp handle_provider_result({:error, error} = err_res, provider, router, metrics) do
-    Logger.warning(
-      "[#{provider.name()}] failed (#{inspect(error)}) in #{Float.round(metrics.latency_ms, 2)} ms"
-    )
-
-    router.on_provider_failure(provider, err_res, metrics)
-    # if failure, we continue with next provider if any
+  defp handle_provider_result({:error, error} = err_res, provider, router) do
+    Logger.warning("[#{provider.name()}] failed: #{inspect(error)}")
+    router.on_provider_failure(provider, err_res, %{})
     {:cont, err_res}
+  end
+
+  @spec run_provider(module(), messages(), Message.t(), keyword()) ::
+          {:ok, any()} | {:error, term()}
+  defp run_provider(provider, messages, system_msg, provider_opts) do
+    provider_name = provider.name()
+    model = Keyword.fetch!(provider_opts, :model)
+
+    :telemetry.span(
+      [:llm_composer, :providers_runner, :call],
+      %{provider: provider_name, model: model},
+      fn ->
+        result = provider.run(messages, system_msg, provider_opts)
+        status = if match?({:ok, _}, result), do: :ok, else: :error
+        {result, %{}, %{provider: provider_name, model: model, status: status}}
+      end
+    )
   end
 
   @spec get_provider_opts(keyword(), Settings.t()) :: keyword()
@@ -99,24 +103,5 @@ defmodule LlmComposer.ProvidersRunner do
     :llm_composer
     |> Application.get_env(:provider_router, [])
     |> Keyword.get(:name, LlmComposer.ProviderRouter.Simple)
-  end
-
-  @spec build_metrics({:ok, LlmResponse.t()} | {:error, term()}, number(), module(), keyword()) ::
-          map()
-  defp build_metrics(result, exec_time_us, provider, provider_opts) do
-    latency_ms = exec_time_us / 1000
-
-    status =
-      case result do
-        {:ok, _} -> :ok
-        {:error, _error} -> :error
-      end
-
-    %{
-      latency_ms: latency_ms,
-      status: status,
-      provider: provider.name(),
-      model: Keyword.fetch!(provider_opts, :model)
-    }
   end
 end

--- a/lib/llm_composer/tool.ex
+++ b/lib/llm_composer/tool.ex
@@ -1,0 +1,156 @@
+defmodule LlmComposer.Tool do
+  @moduledoc """
+  Lightweight DSL for defining LLM tools via a module attribute.
+
+  Annotate any public function with `@tool` and the macro will build the
+  corresponding `LlmComposer.Function` struct at compile time — including a
+  JSON Schema derived from the `args` keyword list — with no boilerplate.
+
+  ## Usage
+
+      defmodule MyApp.Tools do
+        use LlmComposer.Tool
+
+        @tool description: "Evaluates a math expression",
+              args: [expression: [type: :string, required: true, doc: "e.g. \\"2 + 3 * 4\\""]]
+        def calculator(%{"expression" => expr}) do
+          {result, _} = Code.eval_string(expr)
+          result
+        end
+      end
+
+  Then pass the tools to a provider or the agent:
+
+      functions = LlmComposer.Tool.functions(MyApp.Tools)
+
+      settings = %LlmComposer.Settings{
+        providers: [
+          {LlmComposer.Providers.OpenAI,
+           [model: "gpt-4.1-mini", functions: functions]}
+        ],
+        ...
+      }
+
+  ## `@tool` options
+
+  - `:description` (required) — sent to the model to explain the tool
+  - `:args` — keyword list of `{arg_name, arg_opts}`, where `arg_opts` supports:
+    - `:type` — one of `:string`, `:integer`, `:number`, `:boolean`, `:array`,
+      `:object`; defaults to `:string`
+    - `:required` — whether the LLM must supply this argument; defaults to `false`
+    - `:doc` — description of the argument included in the schema
+
+  ## Tool function signature
+
+  Each annotated function must accept a single `map()` argument with string keys
+  (as returned by JSON decoding):
+
+      def my_tool(%{"param" => value}) do
+        ...
+      end
+  """
+
+  alias LlmComposer.Function
+
+  @typedoc "Options accepted by the `:args` list entries."
+  @type arg_opts :: [
+          type: :string | :integer | :number | :boolean | :array | :object,
+          required: boolean(),
+          doc: String.t()
+        ]
+
+  @typedoc "Options for the `@tool` module attribute."
+  @type tool_opts :: [
+          description: String.t(),
+          args: [{atom(), arg_opts()}]
+        ]
+
+  defmacro __using__(_opts) do
+    quote do
+      @on_definition LlmComposer.Tool
+      @before_compile LlmComposer.Tool
+      Module.register_attribute(__MODULE__, :tool, accumulate: false)
+      Module.register_attribute(__MODULE__, :__llm_tool_defs__, accumulate: true)
+    end
+  end
+
+  @doc false
+  @spec __on_definition__(Macro.Env.t(), :def | :defp, atom(), list(), list(), term()) :: :ok
+  def __on_definition__(env, :def, name, _args, _guards, _body) do
+    case Module.get_attribute(env.module, :tool) do
+      nil ->
+        :ok
+
+      opts ->
+        Module.put_attribute(env.module, :__llm_tool_defs__, {name, opts})
+        Module.delete_attribute(env.module, :tool)
+    end
+  end
+
+  def __on_definition__(_env, _kind, _name, _args, _guards, _body), do: :ok
+
+  @doc false
+  defmacro __before_compile__(env) do
+    defs =
+      env.module
+      |> Module.get_attribute(:__llm_tool_defs__)
+      |> Enum.reverse()
+
+    module = env.module
+
+    tool_structs =
+      Enum.map(defs, fn {name, opts} ->
+        %Function{
+          mf: {module, name},
+          name: to_string(name),
+          description: Keyword.fetch!(opts, :description),
+          schema: build_schema(Keyword.get(opts, :args, []))
+        }
+      end)
+
+    quote do
+      @doc false
+      def __llm_tools__, do: unquote(Macro.escape(tool_structs))
+    end
+  end
+
+  @doc """
+  Returns all `LlmComposer.Function` structs defined with `@tool` in `module`.
+  """
+  @spec functions(module()) :: [Function.t()]
+  def functions(module) when is_atom(module), do: module.__llm_tools__()
+
+  @spec build_schema([{atom(), arg_opts()}]) :: map()
+  defp build_schema(args) do
+    properties =
+      Map.new(args, fn {name, opts} ->
+        prop = %{"type" => json_type(Keyword.get(opts, :type, :string))}
+
+        prop =
+          case Keyword.get(opts, :doc) do
+            nil -> prop
+            doc -> Map.put(prop, "description", doc)
+          end
+
+        {to_string(name), prop}
+      end)
+
+    required =
+      args
+      |> Enum.filter(fn {_name, opts} -> Keyword.get(opts, :required, false) end)
+      |> Enum.map(fn {name, _opts} -> to_string(name) end)
+
+    schema = %{"type" => "object", "properties" => properties}
+    if required == [], do: schema, else: Map.put(schema, "required", required)
+  end
+
+  @spec json_type(atom()) :: String.t()
+  defp json_type(:string), do: "string"
+  defp json_type(:integer), do: "integer"
+  defp json_type(:number), do: "number"
+  defp json_type(:float), do: "number"
+  defp json_type(:boolean), do: "boolean"
+  defp json_type(:array), do: "array"
+  defp json_type(:object), do: "object"
+  defp json_type(other), do: to_string(other)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LlmComposer.MixProject do
   def project do
     [
       app: :llm_composer,
-      version: "0.19.6",
+      version: "0.19.5",
       elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -14,6 +14,7 @@ defmodule LlmComposer.MixProject do
         source_ref: "master",
         extras: [
           "README.md",
+          "guides/agent.md",
           "guides/providers.md",
           "guides/streaming.md",
           "guides/cost_tracking.md",
@@ -35,6 +36,10 @@ defmodule LlmComposer.MixProject do
             LlmComposer.LlmResponse,
             LlmComposer.StreamChunk,
             LlmComposer.Function
+          ],
+          Agent: [
+            LlmComposer.Agent,
+            LlmComposer.Agent.Result
           ],
           Providers: ~r/LlmComposer\.Providers\./,
           "Response Parsing": ~r/LlmComposer\.ProviderResponse/,
@@ -61,6 +66,7 @@ defmodule LlmComposer.MixProject do
       ],
       source_url: "https://github.com/doofinder/llm_composer",
       test_coverage: [tool: ExCoveralls],
+      dialyzer: [plt_add_apps: [:credo]],
       aliases: aliases()
     ]
   end
@@ -90,7 +96,7 @@ defmodule LlmComposer.MixProject do
     [
       {:bypass, "~> 2.1", only: :test},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
-      {:decimal, "~> 3.0 or ~> 2.3"},
+      {:decimal, "~> 2.3"},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_aws, "~> 2.6", optional: true},
       {:hackney, "~> 1.21", optional: true},
@@ -100,6 +106,7 @@ defmodule LlmComposer.MixProject do
       {:goth, "~> 1.4", optional: true},
       {:jason, "~> 1.4", optional: is_json_present?},
       {:mint, "~> 1.7"},
+      {:telemetry, "~> 1.0"},
       {:tesla, "~> 1.16"}
     ]
   end

--- a/test/llm_composer/agent_test.exs
+++ b/test/llm_composer/agent_test.exs
@@ -1,0 +1,283 @@
+defmodule LlmComposer.AgentTest do
+  use ExUnit.Case, async: true
+
+  alias LlmComposer.Agent
+  alias LlmComposer.Agent.Result
+  alias LlmComposer.Function
+  alias LlmComposer.Message
+  alias LlmComposer.Providers.OpenAI
+  alias LlmComposer.Settings
+
+  setup do
+    bypass = Bypass.open()
+    {:ok, bypass: bypass}
+  end
+
+  # --- Tool functions invoked by the loop ---
+
+  @spec calculator(map()) :: number()
+  def calculator(%{"expression" => expression}) do
+    {result, _binding} = Code.eval_string(expression)
+    result
+  end
+
+  @spec boom(map()) :: no_return()
+  def boom(_args), do: raise("kaboom")
+
+  # --- Tests ---
+
+  test "runs a single tool round then returns the final answer", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/chat/completions", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      request = Jason.decode!(body)
+
+      if has_tool_message?(request) do
+        # second turn: tool result fed back -> final answer
+        assert tool_result_content(request, "call_1") == "5"
+        json(conn, final_response("The result is 5.", 12, 6))
+      else
+        # first turn: model requests a tool call
+        json(
+          conn,
+          tool_call_response([{"call_1", "calculator", ~s({"expression":"2 + 3"})}], 10, 5)
+        )
+      end
+    end)
+
+    settings = settings(bypass)
+    {:ok, %Result{} = result} = Agent.run(settings, "How much is 2 + 3?")
+
+    assert result.iterations == 2
+    assert result.response.main_response.content == "The result is 5."
+
+    assert [%{name: "calculator", id: "call_1", result: 5}] = result.function_calls
+    assert length(result.cost_infos) == 2
+    assert Enum.map(result.cost_infos, & &1.input_tokens) == [10, 12]
+
+    # full conversation: user, assistant-with-tools, tool_result, final assistant
+    assert [
+             %Message{type: :user},
+             %Message{type: :assistant, function_calls: [_ | _]},
+             %Message{type: :tool_result},
+             %Message{type: :assistant, content: "The result is 5."}
+           ] = result.messages
+  end
+
+  test "returns immediately when the model needs no tools", %{bypass: bypass} do
+    Bypass.expect_once(bypass, "POST", "/chat/completions", fn conn ->
+      json(conn, final_response("Hello there!", 7, 3))
+    end)
+
+    settings = settings(bypass)
+    {:ok, %Result{} = result} = Agent.run(settings, "hi")
+
+    assert result.iterations == 1
+    assert result.response.main_response.content == "Hello there!"
+    assert result.function_calls == []
+  end
+
+  test "returns an error when max_iterations is exceeded", %{bypass: bypass} do
+    # always asks for another tool call -> never converges
+    Bypass.expect(bypass, "POST", "/chat/completions", fn conn ->
+      json(conn, tool_call_response([{"call_x", "calculator", ~s({"expression":"1 + 1"})}], 5, 5))
+    end)
+
+    settings = settings(bypass)
+
+    assert {:error, :max_iterations_reached} =
+             Agent.run(settings, "loop forever", max_iterations: 2)
+  end
+
+  test "feeds tool execution errors back to the model instead of aborting", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/chat/completions", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      request = Jason.decode!(body)
+
+      if has_tool_message?(request) do
+        assert tool_result_content(request, "call_err") =~ "Error: execution failed"
+        json(conn, final_response("Sorry, that tool failed.", 9, 4))
+      else
+        json(conn, tool_call_response([{"call_err", "boom", "{}"}], 8, 3))
+      end
+    end)
+
+    settings = settings(bypass)
+    {:ok, %Result{} = result} = Agent.run(settings, "trigger a failing tool")
+
+    assert result.iterations == 2
+    assert result.response.main_response.content == "Sorry, that tool failed."
+    assert [%{name: "boom", result: "Error: execution failed (kaboom)"}] = result.function_calls
+  end
+
+  test "executes multiple tool calls in parallel preserving order", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/chat/completions", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      request = Jason.decode!(body)
+
+      if has_tool_message?(request) do
+        assert tool_result_content(request, "call_a") == "5"
+        assert tool_result_content(request, "call_b") == "20"
+        json(conn, final_response("Both done.", 15, 5))
+      else
+        json(
+          conn,
+          tool_call_response(
+            [
+              {"call_a", "calculator", ~s({"expression":"2 + 3"})},
+              {"call_b", "calculator", ~s({"expression":"10 * 2"})}
+            ],
+            12,
+            8
+          )
+        )
+      end
+    end)
+
+    settings = settings(bypass)
+
+    {:ok, %Result{} = result} =
+      Agent.run(settings, "do two calcs", tool_execution: :parallel)
+
+    assert result.iterations == 2
+    assert [%{id: "call_a", result: 5}, %{id: "call_b", result: 20}] = result.function_calls
+  end
+
+  test "rejects streaming settings without making a request" do
+    settings = %Settings{
+      providers: [{OpenAI, [model: "gpt-4.1-mini", api_key: "k", url: "http://localhost:0/"]}],
+      system_prompt: "You are a helpful assistant",
+      stream_response: true
+    }
+
+    assert {:error, :streaming_not_supported} = Agent.run(settings, "hi")
+  end
+
+  test "emits run telemetry with iteration count", %{bypass: bypass} do
+    Bypass.expect_once(bypass, "POST", "/chat/completions", fn conn ->
+      json(conn, final_response("done", 4, 2))
+    end)
+
+    handler_id = "agent-telemetry-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:llm_composer, :agent, :run, :stop],
+      fn _event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry_stop, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    settings = settings(bypass)
+    {:ok, _result} = Agent.run(settings, "hi")
+
+    assert_receive {:telemetry_stop, measurements, metadata}
+    assert measurements.iterations == 1
+    assert metadata.status == :ok
+  end
+
+  # --- Helpers ---
+
+  defp settings(bypass) do
+    %Settings{
+      providers: [
+        {OpenAI,
+         [
+           model: "gpt-4.1-mini",
+           api_key: "test-key",
+           url: endpoint_url(bypass.port),
+           functions: [calculator_function(), boom_function()],
+           input_price_per_million: "1.0",
+           output_price_per_million: "2.0"
+         ]}
+      ],
+      system_prompt: "You are a helpful assistant",
+      track_costs: true
+    }
+  end
+
+  defp calculator_function do
+    %Function{
+      mf: {__MODULE__, :calculator},
+      name: "calculator",
+      description: "Evaluate a math expression",
+      schema: %{
+        "type" => "object",
+        "properties" => %{"expression" => %{"type" => "string"}},
+        "required" => ["expression"]
+      }
+    }
+  end
+
+  defp boom_function do
+    %Function{
+      mf: {__MODULE__, :boom},
+      name: "boom",
+      description: "A tool that always raises",
+      schema: %{"type" => "object", "properties" => %{}}
+    }
+  end
+
+  defp has_tool_message?(%{"messages" => messages}) do
+    Enum.any?(messages, &(&1["role"] == "tool"))
+  end
+
+  defp tool_result_content(%{"messages" => messages}, tool_call_id) do
+    Enum.find_value(messages, fn
+      %{"role" => "tool", "tool_call_id" => ^tool_call_id, "content" => content} -> content
+      _message -> nil
+    end)
+  end
+
+  defp tool_call_response(calls, prompt_tokens, completion_tokens) do
+    tool_calls =
+      Enum.map(calls, fn {id, name, arguments} ->
+        %{
+          "id" => id,
+          "type" => "function",
+          "function" => %{"name" => name, "arguments" => arguments}
+        }
+      end)
+
+    %{
+      "id" => "chatcmpl-tool",
+      "object" => "chat.completion",
+      "model" => "gpt-4.1-mini",
+      "choices" => [
+        %{
+          "index" => 0,
+          "message" => %{"role" => "assistant", "content" => nil, "tool_calls" => tool_calls},
+          "finish_reason" => "tool_calls"
+        }
+      ],
+      "usage" => %{"prompt_tokens" => prompt_tokens, "completion_tokens" => completion_tokens}
+    }
+  end
+
+  defp final_response(content, prompt_tokens, completion_tokens) do
+    %{
+      "id" => "chatcmpl-final",
+      "object" => "chat.completion",
+      "model" => "gpt-4.1-mini",
+      "choices" => [
+        %{
+          "index" => 0,
+          "message" => %{"role" => "assistant", "content" => content},
+          "finish_reason" => "stop"
+        }
+      ],
+      "usage" => %{"prompt_tokens" => prompt_tokens, "completion_tokens" => completion_tokens}
+    }
+  end
+
+  defp json(conn, body) do
+    conn
+    |> Plug.Conn.put_resp_header("content-type", "application/json")
+    |> Plug.Conn.resp(200, Jason.encode!(body))
+  end
+
+  defp endpoint_url(port), do: "http://localhost:#{port}/"
+end

--- a/test/llm_composer/tool_test.exs
+++ b/test/llm_composer/tool_test.exs
@@ -1,0 +1,101 @@
+defmodule LlmComposer.ToolTest do
+  use ExUnit.Case, async: true
+
+  defmodule MyTools do
+    use LlmComposer.Tool
+
+    @tool description: "Evaluates a math expression",
+          args: [expression: [type: :string, required: true, doc: "e.g. \"2 + 3\""]]
+    @spec calculator(map()) :: number()
+    def calculator(%{"expression" => expr}) do
+      {result, _} = Code.eval_string(expr)
+      result
+    end
+
+    @tool description: "Greets a person",
+          args: [
+            name: [type: :string, required: true],
+            formal: [type: :boolean]
+          ]
+    @spec greet(map()) :: String.t()
+    def greet(%{"name" => name, "formal" => true}), do: "Good day, #{name}."
+    def greet(%{"name" => name}), do: "Hey, #{name}!"
+
+    @spec not_a_tool(map()) :: :ignored
+    def not_a_tool(_), do: :ignored
+  end
+
+  setup do
+    %{functions: LlmComposer.Tool.functions(MyTools)}
+  end
+
+  describe "functions/1" do
+    test "returns only @tool-annotated functions", %{functions: functions} do
+      names = Enum.map(functions, & &1.name)
+      assert names == ["calculator", "greet"]
+    end
+
+    test "sets the correct mf tuple", %{functions: [calc | _]} do
+      assert calc.mf == {MyTools, :calculator}
+    end
+
+    test "carries the description", %{functions: [calc | _]} do
+      assert calc.description == "Evaluates a math expression"
+    end
+  end
+
+  describe "JSON schema generation" do
+    test "required arg appears in required list", %{functions: [calc | _]} do
+      assert calc.schema["required"] == ["expression"]
+    end
+
+    test "optional arg is not in required list", %{functions: functions} do
+      greet = Enum.find(functions, &(&1.name == "greet"))
+      assert greet.schema["required"] == ["name"]
+      refute "formal" in (greet.schema["required"] || [])
+    end
+
+    test "arg type maps to JSON Schema type string", %{functions: functions} do
+      [calc | _] = functions
+      assert calc.schema["properties"]["expression"]["type"] == "string"
+
+      greet = Enum.find(functions, &(&1.name == "greet"))
+      assert greet.schema["properties"]["formal"]["type"] == "boolean"
+    end
+
+    test "doc is included in property schema", %{functions: [calc | _]} do
+      assert calc.schema["properties"]["expression"]["description"] == "e.g. \"2 + 3\""
+    end
+
+    test "arg without doc has no description key", %{functions: functions} do
+      greet = Enum.find(functions, &(&1.name == "greet"))
+      refute Map.has_key?(greet.schema["properties"]["name"], "description")
+    end
+
+    test "tool with no args produces empty properties and no required" do
+      defmodule NoArgTools do
+        use LlmComposer.Tool
+
+        @tool description: "Pings the system"
+        @spec ping(map()) :: :pong
+        def ping(_), do: :pong
+      end
+
+      [ping] = LlmComposer.Tool.functions(NoArgTools)
+      assert ping.schema == %{"type" => "object", "properties" => %{}}
+    end
+  end
+
+  describe "annotated functions" do
+    test "remain callable and return expected values", %{functions: [calc | _]} do
+      {mod, fun} = calc.mf
+      assert apply(mod, fun, [%{"expression" => "(2 + 3) * 4"}]) == 20
+    end
+
+    test "multi-clause functions are captured once", %{functions: functions} do
+      greet = Enum.find(functions, &(&1.name == "greet"))
+      assert greet != nil
+      assert length(functions) == 2
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

Defining tools today requires writing a `%LlmComposer.Function{}` struct by hand — duplicating the function name as a string, manually writing a JSON Schema, and keeping the `mf` tuple in sync. This PR explores a lighter path.

## What this adds

`LlmComposer.Tool` — a `use`-able module that pairs a `@tool` attribute with the `def` immediately below it and builds the `%Function{}` struct at compile time:

```elixir
defmodule MyApp.Tools do
  use LlmComposer.Tool

  @tool description: "Evaluates a math expression",
        args: [expression: [type: :string, required: true, doc: "e.g. \"2 + 3\""]]
  def calculator(%{"expression" => expr}) do
    {result, _} = Code.eval_string(expr)
    result
  end
end

# Use anywhere a [%Function{}] is expected:
LlmComposer.Tool.functions(MyApp.Tools)
```

The JSON Schema is derived from the `args` keyword list — no hand-written map needed. The `name` is the function name as a string, so no duplication.

## How it works

- `use LlmComposer.Tool` registers an `@on_definition` hook and a `@before_compile` callback
- The hook pairs each `@tool` attribute with the first `def` clause below it
- `__before_compile__` generates a `__llm_tools__/0` function that returns the collected `[%Function{}]` structs
- `LlmComposer.Tool.functions/1` is the public entry point

## What's not here yet

- No `Settings` integration (still pass `LlmComposer.Tool.functions(MyModule)` manually)
- No Spark DSL for full agent configuration
- No nested arg types (array items, object properties)

## Notes

This is a draft to validate the approach before committing to the API surface.