### PR TITLE
Add LlmComposer.Agent.StreamCollector (OpenAI, OpenRouter, Google, Bedrock)

### DIFF
--- a/lib/llm_composer/agent/stream_collector.ex
+++ b/lib/llm_composer/agent/stream_collector.ex
@@ -1,0 +1,293 @@
+defmodule LlmComposer.Agent.StreamCollector do
+  @moduledoc """
+  Accumulates the `LlmComposer.StreamChunk`s of a single agent turn and reassembles them into a
+  synthetic `LlmComposer.LlmResponse`.
+
+  Streaming providers emit tool calls incrementally and in provider-specific shapes:
+
+  - **OpenAI / OpenRouter** send `:tool_call_delta` chunks whose `tool_calls` are raw maps keyed by
+    `"index"`, with the `function.arguments` JSON split across several chunks. They must be grouped
+    by index and concatenated.
+  - **Google** sends already-complete `LlmComposer.FunctionCall` structs (one per chunk).
+  - **Bedrock** sends two event types per tool call: a start event with `"toolUseId"` and `"name"`,
+    followed by one or more delta events that carry only `"inputJson"` fragments. Fragments are
+    grouped by `"toolUseId"` and concatenated in arrival order.
+
+  This collector hides those differences. Feed every chunk of a turn through `add/2`, then call
+  `tool_turn?/1` to know whether the model requested tools, and `to_llm_response/1` to obtain a
+  response shaped exactly like a non-streaming one (so the rest of `LlmComposer.Agent` can reuse the
+  synchronous loop unchanged).
+  """
+
+  alias LlmComposer.CostInfo
+  alias LlmComposer.FunctionCall
+  alias LlmComposer.FunctionCallExtractors
+  alias LlmComposer.LlmResponse
+  alias LlmComposer.Message
+  alias LlmComposer.StreamChunk
+
+  @supported_providers [:open_ai, :open_router, :google, :bedrock]
+
+  @type t() :: %__MODULE__{
+          provider: atom(),
+          text: iodata(),
+          reasoning: iodata(),
+          tool_fragments: %{optional(non_neg_integer() | String.t()) => map()},
+          tool_id_sequence: [String.t()],
+          current_tool_id: String.t() | nil,
+          function_calls: [FunctionCall.t()],
+          saw_tool_call: boolean(),
+          usage: StreamChunk.usage() | nil,
+          cost_info: CostInfo.t() | nil
+        }
+
+  defstruct provider: nil,
+            text: [],
+            reasoning: [],
+            tool_fragments: %{},
+            tool_id_sequence: [],
+            current_tool_id: nil,
+            function_calls: [],
+            saw_tool_call: false,
+            usage: nil,
+            cost_info: nil
+
+  @doc """
+  Creates a collector for the given provider.
+
+  Raises `ArgumentError` for providers that are not yet supported by the streaming agent.
+  """
+  @spec new(atom()) :: t()
+  def new(provider) when provider in @supported_providers do
+    %__MODULE__{provider: provider}
+  end
+
+  def new(provider) do
+    raise ArgumentError,
+          "streaming agent does not support provider #{inspect(provider)} yet " <>
+            "(supported: #{inspect(@supported_providers)})"
+  end
+
+  @doc """
+  Accumulates a single `LlmComposer.StreamChunk` into the collector.
+  """
+  @spec add(t(), StreamChunk.t()) :: t()
+  def add(%__MODULE__{} = collector, %StreamChunk{type: :text_delta, text: text})
+      when is_binary(text) do
+    %{collector | text: [collector.text, text]}
+  end
+
+  def add(%__MODULE__{} = collector, %StreamChunk{type: :reasoning_delta, reasoning: reasoning})
+      when is_binary(reasoning) do
+    %{collector | reasoning: [collector.reasoning, reasoning]}
+  end
+
+  def add(%__MODULE__{} = collector, %StreamChunk{type: :tool_call_delta, tool_calls: tool_calls})
+      when is_list(tool_calls) do
+    collector
+    |> Map.put(:saw_tool_call, true)
+    |> merge_tool_calls(tool_calls)
+  end
+
+  def add(%__MODULE__{} = collector, %StreamChunk{} = chunk) do
+    collector
+    |> maybe_put_usage(chunk.usage)
+    |> maybe_put_cost_info(chunk.cost_info)
+  end
+
+  @doc """
+  Returns `true` once any tool-call delta has been accumulated.
+  """
+  @spec tool_turn?(t()) :: boolean()
+  def tool_turn?(%__MODULE__{saw_tool_call: saw_tool_call}), do: saw_tool_call
+
+  @doc """
+  Returns the accumulated reasoning text, or `nil` when none was streamed.
+  """
+  @spec reasoning(t()) :: String.t() | nil
+  def reasoning(%__MODULE__{reasoning: reasoning}), do: blank_to_nil(reasoning)
+
+  @doc """
+  Finalizes the accumulated tool-call deltas into complete `LlmComposer.FunctionCall` structs.
+  """
+  @spec to_function_calls(t()) :: [FunctionCall.t()]
+  def to_function_calls(%__MODULE__{provider: :google, function_calls: calls}), do: calls
+
+  def to_function_calls(%__MODULE__{provider: p, tool_fragments: fragments})
+      when p in [:open_ai, :open_router] do
+    fragments
+    |> Enum.sort_by(fn {index, _fragment} -> index end)
+    |> Enum.map(fn {_index, fragment} -> fragment end)
+    |> then(&FunctionCallExtractors.from_tool_calls(%{"tool_calls" => &1}))
+    |> List.wrap()
+  end
+
+  def to_function_calls(%__MODULE__{
+        provider: :bedrock,
+        tool_fragments: fragments,
+        tool_id_sequence: order
+      }) do
+    Enum.map(order, fn tool_id ->
+      %{"toolUseId" => id, "name" => name, "inputJson" => args} = Map.fetch!(fragments, tool_id)
+      %FunctionCall{id: id, name: name, arguments: args, type: "function"}
+    end)
+  end
+
+  @doc """
+  Builds a synthetic `LlmComposer.LlmResponse` equivalent to a non-streaming response for the turn.
+
+  The returned response has an `:assistant` `main_response` carrying the accumulated text, reasoning
+  and reassembled function calls, plus token usage and cost info captured from the stream.
+  """
+  @spec to_llm_response(t()) :: LlmResponse.t()
+  def to_llm_response(%__MODULE__{} = collector) do
+    usage = collector.usage || %{}
+    function_calls = to_function_calls(collector)
+
+    main_response = %Message{
+      type: :assistant,
+      content: blank_to_nil(collector.text),
+      function_calls: function_calls,
+      reasoning: blank_to_nil(collector.reasoning),
+      metadata: %{}
+    }
+
+    LlmResponse.new(%{
+      provider: collector.provider,
+      status: :ok,
+      main_response: main_response,
+      input_tokens: Map.get(usage, :input_tokens),
+      output_tokens: Map.get(usage, :output_tokens),
+      cached_tokens: Map.get(usage, :cached_tokens),
+      reasoning_tokens: Map.get(usage, :reasoning_tokens),
+      cost_info: collector.cost_info
+    })
+  end
+
+  @doc """
+  Sums a list of per-turn `LlmComposer.CostInfo` into a single aggregate, or `nil` when empty.
+
+  Token counts are added and `Decimal` cost fields are summed. `provider_name`, `provider_model`
+  and `currency` are taken from the first entry (a run may span models).
+  """
+  @spec aggregate_cost_infos([CostInfo.t()]) :: CostInfo.t() | nil
+  def aggregate_cost_infos([]), do: nil
+
+  def aggregate_cost_infos([first | _] = cost_infos) do
+    initial = %CostInfo{
+      provider_name: first.provider_name,
+      provider_model: first.provider_model,
+      currency: first.currency,
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+      cached_tokens: 0,
+      input_cost: nil,
+      output_cost: nil,
+      total_cost: nil,
+      metadata: %{aggregated: true, count: length(cost_infos)}
+    }
+
+    Enum.reduce(cost_infos, initial, fn cost_info, acc ->
+      %CostInfo{
+        acc
+        | input_tokens: acc.input_tokens + (cost_info.input_tokens || 0),
+          output_tokens: acc.output_tokens + (cost_info.output_tokens || 0),
+          total_tokens: acc.total_tokens + (cost_info.total_tokens || 0),
+          cached_tokens: acc.cached_tokens + (cost_info.cached_tokens || 0),
+          input_cost: add_decimal(acc.input_cost, cost_info.input_cost),
+          output_cost: add_decimal(acc.output_cost, cost_info.output_cost),
+          total_cost: add_decimal(acc.total_cost, cost_info.total_cost)
+      }
+    end)
+  end
+
+  # Private functions
+
+  @spec merge_tool_calls(t(), [map() | FunctionCall.t()]) :: t()
+  defp merge_tool_calls(%__MODULE__{provider: :google} = collector, tool_calls) do
+    new_calls = Enum.filter(tool_calls, &match?(%FunctionCall{}, &1))
+    %{collector | function_calls: collector.function_calls ++ new_calls}
+  end
+
+  defp merge_tool_calls(%__MODULE__{provider: p} = collector, tool_calls)
+       when p in [:open_ai, :open_router] do
+    fragments =
+      Enum.reduce(tool_calls, collector.tool_fragments, fn raw, acc ->
+        index = Map.get(raw, "index", map_size(acc))
+        Map.update(acc, index, raw, &merge_fragment(&1, raw))
+      end)
+
+    %{collector | tool_fragments: fragments}
+  end
+
+  defp merge_tool_calls(%__MODULE__{provider: :bedrock} = collector, tool_calls) do
+    Enum.reduce(tool_calls, collector, fn
+      %{"toolUseId" => tool_id, "name" => name} = raw, acc ->
+        fragment = %{
+          "toolUseId" => tool_id,
+          "name" => name,
+          "inputJson" => Map.get(raw, "inputJson", "")
+        }
+
+        %{
+          acc
+          | tool_fragments: Map.put(acc.tool_fragments, tool_id, fragment),
+            tool_id_sequence: acc.tool_id_sequence ++ [tool_id],
+            current_tool_id: tool_id
+        }
+
+      %{"inputJson" => input}, acc when is_binary(input) ->
+        tool_id = acc.current_tool_id
+
+        fragments =
+          Map.update!(acc.tool_fragments, tool_id, fn f ->
+            Map.update(f, "inputJson", input, &(&1 <> input))
+          end)
+
+        %{acc | tool_fragments: fragments}
+    end)
+  end
+
+  @spec merge_fragment(map(), map()) :: map()
+  defp merge_fragment(existing, incoming) do
+    Map.merge(existing, incoming, fn
+      "function", existing_fun, incoming_fun -> merge_function(existing_fun, incoming_fun)
+      _key, existing_val, incoming_val -> existing_val || incoming_val
+    end)
+  end
+
+  @spec merge_function(map(), map()) :: map()
+  defp merge_function(existing_fun, incoming_fun) do
+    existing_args = Map.get(existing_fun, "arguments", "")
+    incoming_args = Map.get(incoming_fun, "arguments", "")
+
+    existing_fun
+    |> Map.merge(incoming_fun, fn _key, existing_val, incoming_val ->
+      existing_val || incoming_val
+    end)
+    |> Map.put("arguments", (existing_args || "") <> (incoming_args || ""))
+  end
+
+  @spec maybe_put_usage(t(), StreamChunk.usage() | nil) :: t()
+  defp maybe_put_usage(collector, nil), do: collector
+  defp maybe_put_usage(collector, usage), do: %{collector | usage: usage}
+
+  @spec maybe_put_cost_info(t(), CostInfo.t() | nil) :: t()
+  defp maybe_put_cost_info(collector, nil), do: collector
+  defp maybe_put_cost_info(collector, cost_info), do: %{collector | cost_info: cost_info}
+
+  @spec blank_to_nil(iodata()) :: String.t() | nil
+  defp blank_to_nil(iodata) do
+    case IO.iodata_to_binary(iodata) do
+      "" -> nil
+      binary -> binary
+    end
+  end
+
+  @spec add_decimal(Decimal.t() | nil, Decimal.t() | nil) :: Decimal.t() | nil
+  defp add_decimal(nil, nil), do: nil
+  defp add_decimal(nil, value), do: value
+  defp add_decimal(value, nil), do: value
+  defp add_decimal(left, right), do: Decimal.add(left, right)
+end

--- a/test/llm_composer/agent/stream_collector_test.exs
+++ b/test/llm_composer/agent/stream_collector_test.exs
@@ -1,0 +1,301 @@
+defmodule LlmComposer.Agent.StreamCollectorTest do
+  use ExUnit.Case, async: true
+
+  alias LlmComposer.Agent.StreamCollector
+  alias LlmComposer.CostInfo
+  alias LlmComposer.FunctionCall
+  alias LlmComposer.LlmResponse
+  alias LlmComposer.StreamChunk
+
+  describe "OpenAI tool-call reassembly" do
+    test "merges fragmented arguments by index into a single FunctionCall" do
+      chunks = [
+        tool_chunk([
+          %{
+            "index" => 0,
+            "id" => "call_1",
+            "type" => "function",
+            "function" => %{"name" => "get_weather", "arguments" => ""}
+          }
+        ]),
+        tool_chunk([%{"index" => 0, "function" => %{"arguments" => "{\"loc"}}]),
+        tool_chunk([%{"index" => 0, "function" => %{"arguments" => "ation\":\"Paris\"}"}}])
+      ]
+
+      collector = collect(:open_ai, chunks)
+
+      assert StreamCollector.tool_turn?(collector)
+
+      assert [%FunctionCall{id: "call_1", name: "get_weather", arguments: args, type: "function"}] =
+               StreamCollector.to_function_calls(collector)
+
+      assert args == "{\"location\":\"Paris\"}"
+    end
+
+    test "keeps multiple parallel tool calls separated by index" do
+      chunks = [
+        tool_chunk([
+          %{
+            "index" => 0,
+            "id" => "a",
+            "type" => "function",
+            "function" => %{"name" => "f", "arguments" => "{\"x\":1}"}
+          },
+          %{
+            "index" => 1,
+            "id" => "b",
+            "type" => "function",
+            "function" => %{"name" => "g", "arguments" => "{\"y\":2}"}
+          }
+        ])
+      ]
+
+      collector = collect(:open_ai, chunks)
+
+      assert [%FunctionCall{id: "a", name: "f"}, %FunctionCall{id: "b", name: "g"}] =
+               StreamCollector.to_function_calls(collector)
+    end
+  end
+
+  describe "Google tool-call collection" do
+    test "collects already-complete FunctionCall structs" do
+      call = %FunctionCall{
+        id: "http_client",
+        name: "http_client",
+        arguments: "{}",
+        type: "function"
+      }
+
+      chunk = %StreamChunk{provider: :google, type: :tool_call_delta, tool_calls: [call]}
+
+      collector = collect(:google, [chunk])
+
+      assert StreamCollector.tool_turn?(collector)
+      assert StreamCollector.to_function_calls(collector) == [call]
+    end
+  end
+
+  describe "to_llm_response/1" do
+    test "builds a final assistant response from text and usage" do
+      collector =
+        collect(:open_ai, [
+          text_chunk("Hello "),
+          text_chunk("world"),
+          usage_chunk(%{input_tokens: 10, output_tokens: 4})
+        ])
+
+      assert %LlmResponse{
+               provider: :open_ai,
+               status: :ok,
+               input_tokens: 10,
+               output_tokens: 4,
+               main_response: %{type: :assistant, content: "Hello world", function_calls: []}
+             } = StreamCollector.to_llm_response(collector)
+    end
+
+    test "exposes reassembled tool calls as the response function_calls" do
+      collector =
+        collect(:open_ai, [
+          tool_chunk([
+            %{
+              "index" => 0,
+              "id" => "c",
+              "type" => "function",
+              "function" => %{"name" => "f", "arguments" => "{}"}
+            }
+          ])
+        ])
+
+      assert [%FunctionCall{name: "f"}] =
+               StreamCollector.to_llm_response(collector).main_response.function_calls
+    end
+  end
+
+  describe "aggregate_cost_infos/1" do
+    test "returns nil for an empty list" do
+      assert StreamCollector.aggregate_cost_infos([]) == nil
+    end
+
+    test "sums tokens and Decimal costs across turns" do
+      a = cost_info(10, 5, "0.10")
+      b = cost_info(20, 8, "0.20")
+
+      assert %CostInfo{input_tokens: 30, output_tokens: 13, total_tokens: 43, total_cost: total} =
+               StreamCollector.aggregate_cost_infos([a, b])
+
+      assert Decimal.equal?(total, Decimal.new("0.30"))
+    end
+  end
+
+  describe "OpenRouter tool-call reassembly" do
+    test "merges fragmented arguments by index (same format as OpenAI)" do
+      chunks = [
+        %StreamChunk{
+          provider: :open_router,
+          type: :tool_call_delta,
+          tool_calls: [
+            %{
+              "index" => 0,
+              "id" => "call_or_1",
+              "type" => "function",
+              "function" => %{"name" => "get_weather", "arguments" => ""}
+            }
+          ]
+        },
+        %StreamChunk{
+          provider: :open_router,
+          type: :tool_call_delta,
+          tool_calls: [%{"index" => 0, "function" => %{"arguments" => "{\"city\":"}}]
+        },
+        %StreamChunk{
+          provider: :open_router,
+          type: :tool_call_delta,
+          tool_calls: [%{"index" => 0, "function" => %{"arguments" => "\"Paris\"}"}}]
+        }
+      ]
+
+      collector = collect(:open_router, chunks)
+
+      assert StreamCollector.tool_turn?(collector)
+
+      assert [
+               %FunctionCall{
+                 id: "call_or_1",
+                 name: "get_weather",
+                 arguments: "{\"city\":\"Paris\"}",
+                 type: "function"
+               }
+             ] = StreamCollector.to_function_calls(collector)
+    end
+  end
+
+  describe "Bedrock tool-call reassembly" do
+    test "merges a start chunk and inputJson deltas into a FunctionCall" do
+      chunks = [
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"toolUseId" => "bedrock_1", "name" => "calculator", "inputJson" => ""}]
+        },
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"inputJson" => "{\"expression\":"}]
+        },
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"inputJson" => "\"2 + 3\"}"}]
+        }
+      ]
+
+      collector = collect(:bedrock, chunks)
+
+      assert StreamCollector.tool_turn?(collector)
+
+      assert [
+               %FunctionCall{
+                 id: "bedrock_1",
+                 name: "calculator",
+                 arguments: "{\"expression\":\"2 + 3\"}",
+                 type: "function"
+               }
+             ] = StreamCollector.to_function_calls(collector)
+    end
+
+    test "preserves insertion order for multiple sequential tool calls" do
+      chunks = [
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"toolUseId" => "id_a", "name" => "tool_a", "inputJson" => ""}]
+        },
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"inputJson" => "{\"x\":1}"}]
+        },
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"toolUseId" => "id_b", "name" => "tool_b", "inputJson" => ""}]
+        },
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"inputJson" => "{\"y\":2}"}]
+        }
+      ]
+
+      collector = collect(:bedrock, chunks)
+
+      assert [
+               %FunctionCall{id: "id_a", name: "tool_a", arguments: "{\"x\":1}"},
+               %FunctionCall{id: "id_b", name: "tool_b", arguments: "{\"y\":2}"}
+             ] = StreamCollector.to_function_calls(collector)
+    end
+
+    test "to_llm_response/1 exposes assembled Bedrock tool calls" do
+      chunks = [
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"toolUseId" => "bid_1", "name" => "lookup", "inputJson" => "{}"}]
+        },
+        %StreamChunk{
+          provider: :bedrock,
+          type: :usage,
+          usage: %{input_tokens: 8, output_tokens: 3}
+        }
+      ]
+
+      collector = collect(:bedrock, chunks)
+
+      assert %LlmResponse{
+               provider: :bedrock,
+               status: :ok,
+               input_tokens: 8,
+               output_tokens: 3,
+               main_response: %{
+                 type: :assistant,
+                 function_calls: [%FunctionCall{id: "bid_1", name: "lookup", arguments: "{}"}]
+               }
+             } = StreamCollector.to_llm_response(collector)
+    end
+  end
+
+  test "new/1 raises for unsupported providers" do
+    assert_raise ArgumentError, fn -> StreamCollector.new(:ollama) end
+  end
+
+  # --- Helpers ---
+
+  defp collect(provider, chunks) do
+    Enum.reduce(chunks, StreamCollector.new(provider), &StreamCollector.add(&2, &1))
+  end
+
+  defp tool_chunk(tool_calls) do
+    %StreamChunk{provider: :open_ai, type: :tool_call_delta, tool_calls: tool_calls}
+  end
+
+  defp text_chunk(text) do
+    %StreamChunk{provider: :open_ai, type: :text_delta, text: text}
+  end
+
+  defp usage_chunk(usage) do
+    %StreamChunk{provider: :open_ai, type: :usage, usage: usage}
+  end
+
+  defp cost_info(input_tokens, output_tokens, total_cost) do
+    %CostInfo{
+      provider_name: :open_ai,
+      provider_model: "gpt-4.1-mini",
+      currency: "USD",
+      input_tokens: input_tokens,
+      output_tokens: output_tokens,
+      total_tokens: input_tokens + output_tokens,
+      cached_tokens: 0,
+      total_cost: Decimal.new(total_cost)
+    }
+  end
+end


### PR DESCRIPTION
## PR Series

| PR | Description |
|---|---|
| **👉 [#116](https://github.com/doofinder/llm_composer/pull/116)** | **Add StreamCollector — all four streaming providers (OpenAI, OpenRouter, Google, Bedrock)** |
| [#117](https://github.com/doofinder/llm_composer/pull/117) | Add streaming support to Agent with `:tool_call` stream chunks |
| [#118](https://github.com/doofinder/llm_composer/pull/118) | Docs and changelog for Agent streaming |

---

## TL;DR

An accumulator for stream chunks, for later usage in Agent module with `stream: true`

why? to get tool chunk assembled (some providers emits parts of it, like openai that streams very small chunks)

## Summary

Introduces `LlmComposer.Agent.StreamCollector` — the module that accumulates streaming chunks of a single agent turn and reassembles them into a synthetic `LlmResponse` identical in shape to a non-streaming response, so the rest of the agent loop can reuse the synchronous code paths unchanged.

**Provider strategies:**

| Provider | Tool-call delta format | Reassembly strategy |
|---|---|---|
| `:open_ai` / `:open_router` | Raw maps keyed by `"index"`, JSON arguments split across chunks | Group by index, concatenate `"function"."arguments"` strings |
| `:google` | Already-complete `FunctionCall` structs | Collect directly |
| `:bedrock` | Start event (`toolUseId` + `name`), then `inputJson`-only deltas | Group by `toolUseId`, concatenate `"inputJson"` in insertion order via `tool_id_sequence` |

Also adds `StreamCollector.aggregate_cost_infos/1` for summing per-turn `CostInfo` structs into a single run-level aggregate.

## Test plan

- [x] `mix test test/llm_composer/agent/stream_collector_test.exs` — unit tests for all four providers and aggregation
- [x] `mix precommit`