### PR TITLE
Add streaming support to LlmComposer.Agent with :tool_call stream chunks

### DIFF
--- a/lib/llm_composer/agent.ex
+++ b/lib/llm_composer/agent.ex
@@ -10,7 +10,32 @@ defmodule LlmComposer.Agent do
 
   The loop is pure orchestration over existing building blocks
   (`LlmComposer.FunctionExecutor`, `LlmComposer.FunctionCallHelpers`) and does not change any
-  provider behaviour. It is **synchronous** — streaming is not supported in this version.
+  provider behaviour.
+
+  ## Streaming
+
+  When `settings.stream_response` is `true`, `run/3` returns `{:ok, stream}` where `stream` is a
+  lazy `Enumerable` of `LlmComposer.StreamChunk`. The stream carries **only the final, tool-free
+  answer** (token-by-token `:text_delta` chunks) followed by a terminal `:done` chunk whose `:usage`
+  and `:cost_info` hold the run totals and whose `metadata.agent_result` holds the full
+  `LlmComposer.Agent.Result`. A hard failure (e.g. `:max_iterations_reached`) is delivered as a
+  terminal `:error` chunk instead.
+
+  Intermediate progress — tool calls, per-iteration data and reasoning — is **not** placed on the
+  answer stream. It is exposed via `:telemetry` (see below) so a UI can subscribe without having to
+  filter the answer.
+
+      {:ok, stream} = LlmComposer.Agent.run(settings, "Weather in Paris?")
+
+      stream
+      |> Enum.reduce(nil, fn
+        %LlmComposer.StreamChunk{type: :text_delta, text: t}, acc -> IO.write(t); acc
+        %LlmComposer.StreamChunk{type: :done, metadata: %{agent_result: r}}, _ -> r
+        _other, acc -> acc
+      end)
+
+  Only the `:open_ai` and `:google` providers support the streaming agent today; others yield a
+  terminal `:error` chunk with `{:streaming_agent_unsupported_provider, provider}`.
 
   ## Example
 
@@ -69,17 +94,32 @@ defmodule LlmComposer.Agent do
 
   ## Telemetry
 
-  The loop emits the following `:telemetry` events:
+  The loop emits the following `:telemetry` events (in both synchronous and streaming modes):
 
   - `[:llm_composer, :agent, :run, :start | :stop | :exception]` — the whole run. The `:stop`
-    event includes an `:iterations` measurement and a `:status` (`:ok`/`:error`) metadata key.
+    event includes an `:iterations` measurement and a `:status` (`:ok`/`:error`/`:halted`) metadata
+    key.
   - `[:llm_composer, :agent, :iteration, :stop]` — one per model turn. Measurement
     `:tool_call_count`; metadata `:iteration`, `:cost_info`, `:final`.
   - `[:llm_composer, :agent, :tool, :start | :stop | :exception]` — one per tool execution.
-    Metadata `:name` and (on stop) `:status` (`:ok`/`:error`).
+    Metadata `:name`, `:arguments`, `:metadata`, `:id` and (on stop) `:status` (`:ok`/`:error`).
+  - `[:llm_composer, :agent, :reasoning, :delta]` — streaming only: one per intermediate reasoning
+    fragment. Metadata `:iteration` and `:reasoning`.
+
+  Pass `telemetry_metadata: map()` to `run/3` and the map is merged into the metadata of every event
+  above, alongside an auto-generated `:run_id`. This lets a handler scope itself to a single run and,
+  for example, broadcast to `Phoenix.PubSub` or `send/2` a pid:
+
+      {:ok, _} = LlmComposer.Agent.run(settings, prompt, telemetry_metadata: %{conversation_id: cid})
+
+      :telemetry.attach("agent-ui", [:llm_composer, :agent, :tool, :start], fn
+        _event, _meas, %{conversation_id: ^cid, name: name, arguments: args}, _cfg ->
+          Phoenix.PubSub.broadcast(MyApp.PubSub, "conv:\#{cid}", {:tool_call, name, args})
+      end, nil)
   """
 
   alias LlmComposer.Agent.Result
+  alias LlmComposer.Agent.StreamCollector
   alias LlmComposer.CostInfo
   alias LlmComposer.Function
   alias LlmComposer.FunctionCall
@@ -88,6 +128,7 @@ defmodule LlmComposer.Agent do
   alias LlmComposer.LlmResponse
   alias LlmComposer.Message
   alias LlmComposer.Settings
+  alias LlmComposer.StreamChunk
 
   require Logger
 
@@ -99,7 +140,8 @@ defmodule LlmComposer.Agent do
           max_iterations: pos_integer(),
           functions: [Function.t()],
           tool_execution: :sequential | :parallel,
-          tool_timeout: timeout()
+          tool_timeout: timeout(),
+          telemetry_metadata: map()
         ]
 
   @typep config() :: %{
@@ -107,7 +149,8 @@ defmodule LlmComposer.Agent do
            functions: [Function.t()],
            max_iterations: pos_integer(),
            tool_execution: :sequential | :parallel,
-           tool_timeout: timeout()
+           tool_timeout: timeout(),
+           telemetry_ctx: map()
          }
 
   @typep acc() :: %{cost_infos: [CostInfo.t()], function_calls: [FunctionCall.t()]}
@@ -118,36 +161,67 @@ defmodule LlmComposer.Agent do
   Accepts either a user prompt string (wrapped into a `:user` message, honouring the settings'
   `:user_prompt_prefix`) or an explicit list of `LlmComposer.Message.t()`.
 
-  Returns `{:ok, %LlmComposer.Agent.Result{}}` on success, or `{:error, reason}` where `reason`
-  may be `:max_iterations_reached`, `:streaming_not_supported`, or any error returned by the
-  underlying provider.
+  When `settings.stream_response` is `false`, returns `{:ok, %LlmComposer.Agent.Result{}}` on success
+  or `{:error, reason}` (where `reason` may be `:max_iterations_reached` or any error returned by the
+  underlying provider). When `settings.stream_response` is `true`, returns `{:ok, stream}` — see the
+  "Streaming" section of the module documentation.
 
   See the module documentation for the available options.
   """
-  @spec run(Settings.t(), input(), run_opts()) :: {:ok, Result.t()} | {:error, term()}
+  @spec run(Settings.t(), input(), run_opts()) ::
+          {:ok, Result.t()} | {:ok, Enumerable.t()} | {:error, term()}
   def run(settings, input, opts \\ [])
 
-  def run(%Settings{stream_response: true}, _input, _opts), do: {:error, :streaming_not_supported}
-
   def run(%Settings{} = settings, input, opts) do
-    functions = Keyword.get(opts, :functions) || functions_from_settings(settings)
-    max_iterations = Keyword.get(opts, :max_iterations, @default_max_iterations)
+    config = build_config(settings, opts)
+    messages = normalize_input(settings, input)
 
-    config = %{
+    if settings.stream_response do
+      {:ok, build_agent_stream(config, messages)}
+    else
+      run_sync(config, messages)
+    end
+  end
+
+  # --- Configuration ---
+
+  @spec build_config(Settings.t(), run_opts()) :: config()
+  defp build_config(settings, opts) do
+    functions = Keyword.get(opts, :functions) || functions_from_settings(settings)
+
+    telemetry_ctx =
+      opts
+      |> Keyword.get(:telemetry_metadata, %{})
+      |> Map.put(:run_id, System.unique_integer([:positive]))
+
+    %{
       settings: settings,
       functions: functions,
-      max_iterations: max_iterations,
+      max_iterations: Keyword.get(opts, :max_iterations, @default_max_iterations),
       tool_execution: Keyword.get(opts, :tool_execution, :sequential),
-      tool_timeout: Keyword.get(opts, :tool_timeout, :infinity)
+      tool_timeout: Keyword.get(opts, :tool_timeout, :infinity),
+      telemetry_ctx: telemetry_ctx
     }
+  end
 
-    messages = normalize_input(settings, input)
-    start_metadata = %{max_iterations: max_iterations, tool_count: length(functions)}
+  # --- Synchronous loop ---
+
+  @spec run_sync(config(), [Message.t()]) :: {:ok, Result.t()} | {:error, term()}
+  defp run_sync(config, messages) do
+    start_metadata = run_start_metadata(config)
 
     :telemetry.span([:llm_composer, :agent, :run], start_metadata, fn ->
       result = loop(config, messages, 0, new_acc())
       {result, run_measurements(result), run_stop_metadata(start_metadata, result)}
     end)
+  end
+
+  @spec run_start_metadata(config()) :: map()
+  defp run_start_metadata(config) do
+    Map.merge(config.telemetry_ctx, %{
+      max_iterations: config.max_iterations,
+      tool_count: length(config.functions)
+    })
   end
 
   # --- Loop ---
@@ -179,33 +253,46 @@ defmodule LlmComposer.Agent do
 
     case LlmResponse.function_calls(response) do
       calls when calls in [nil, []] ->
-        emit_iteration(next_iteration, response.cost_info, 0, true)
+        emit_iteration(config.telemetry_ctx, next_iteration, response.cost_info, 0, true)
         finalize(response, messages, next_iteration, %{acc | cost_infos: cost_infos})
 
       calls ->
         executed = execute_tool_calls(config, calls)
-        emit_iteration(next_iteration, response.cost_info, length(calls), false)
 
-        provider_mod = resolve_provider_module(config.settings, response.provider)
-        provider_opts = provider_opts_for(config.settings, provider_mod)
-
-        assistant_msg =
-          FunctionCallHelpers.build_assistant_with_tools(
-            provider_mod,
-            response,
-            last_user_message(messages),
-            provider_opts
-          )
-
-        tool_msgs = FunctionCallHelpers.build_tool_result_messages(executed)
+        emit_iteration(
+          config.telemetry_ctx,
+          next_iteration,
+          response.cost_info,
+          length(calls),
+          false
+        )
 
         loop(
           config,
-          messages ++ [assistant_msg | tool_msgs],
+          apply_tool_turn(config, messages, response, executed),
           next_iteration,
           %{acc | cost_infos: cost_infos, function_calls: acc.function_calls ++ executed}
         )
     end
+  end
+
+  @spec apply_tool_turn(config(), [Message.t()], LlmResponse.t(), [FunctionCall.t()]) ::
+          [Message.t()]
+  defp apply_tool_turn(config, messages, response, executed) do
+    provider_mod = resolve_provider_module(config.settings, response.provider)
+    provider_opts = provider_opts_for(config.settings, provider_mod)
+
+    assistant_msg =
+      FunctionCallHelpers.build_assistant_with_tools(
+        provider_mod,
+        response,
+        last_user_message(messages),
+        provider_opts
+      )
+
+    tool_msgs = FunctionCallHelpers.build_tool_result_messages(executed)
+
+    messages ++ [assistant_msg | tool_msgs]
   end
 
   @spec finalize(LlmResponse.t(), [Message.t()], non_neg_integer(), acc()) :: {:ok, Result.t()}
@@ -219,6 +306,230 @@ defmodule LlmComposer.Agent do
        function_calls: acc.function_calls
      }}
   end
+
+  # --- Streaming loop ---
+
+  @spec build_agent_stream(config(), [Message.t()]) :: Enumerable.t()
+  defp build_agent_stream(config, messages) do
+    Stream.resource(
+      fn -> start_stream(config, messages) end,
+      &step/1,
+      &finish_stream/1
+    )
+  end
+
+  @spec start_stream(config(), [Message.t()]) :: map()
+  defp start_stream(config, messages) do
+    :telemetry.execute([:llm_composer, :agent, :run, :start], %{}, run_start_metadata(config))
+
+    %{
+      config: config,
+      phase: :start_turn,
+      messages: messages,
+      iteration: 0,
+      acc: new_acc(),
+      usage: %{},
+      cont: nil,
+      collector: nil,
+      status: :running
+    }
+  end
+
+  @spec step(map()) :: {[StreamChunk.t()], map()} | {:halt, map()}
+  defp step(%{phase: :done} = state), do: {:halt, state}
+  defp step(%{phase: :start_turn} = state), do: start_turn(state)
+  defp step(%{phase: :drive} = state), do: drive_turn(state)
+
+  @spec start_turn(map()) :: {[StreamChunk.t()], map()}
+  defp start_turn(%{config: config, iteration: iteration} = state) do
+    if iteration >= config.max_iterations do
+      terminate_error(state, :max_iterations_reached)
+    else
+      begin_turn(state)
+    end
+  end
+
+  @spec begin_turn(map()) :: {[StreamChunk.t()], map()}
+  defp begin_turn(%{config: config, messages: messages} = state) do
+    case LlmComposer.run_completion(config.settings, messages) do
+      {:ok, %LlmResponse{stream: nil} = response} ->
+        # provider ignored stream_response and returned a complete response: handle it directly
+        handle_complete_response(state, response)
+
+      {:ok, %LlmResponse{stream: stream, provider: provider}} ->
+        setup_drive(state, provider, stream)
+
+      {:error, reason} ->
+        terminate_error(state, reason)
+    end
+  end
+
+  @spec setup_drive(map(), atom(), Enumerable.t()) :: {[StreamChunk.t()], map()}
+  defp setup_drive(%{config: config} = state, provider, stream) do
+    collector = StreamCollector.new(provider)
+
+    parsed =
+      LlmComposer.parse_stream_response(stream, provider, provider_pricing_opts(config, provider))
+
+    {[], %{state | phase: :drive, collector: collector, cont: init_puller(parsed)}}
+  rescue
+    ArgumentError -> terminate_error(state, {:streaming_agent_unsupported_provider, provider})
+  end
+
+  @spec drive_turn(map()) :: {[StreamChunk.t()], map()}
+  defp drive_turn(%{cont: cont, collector: collector} = state) do
+    case pull(cont) do
+      {:chunk, chunk, next_cont} ->
+        state = %{state | collector: StreamCollector.add(collector, chunk), cont: next_cont}
+        forward_chunk(state, chunk)
+
+      :done ->
+        handle_complete_response(state, StreamCollector.to_llm_response(collector))
+    end
+  end
+
+  @spec forward_chunk(map(), StreamChunk.t()) :: {[StreamChunk.t()], map()}
+  defp forward_chunk(state, %StreamChunk{type: :text_delta} = chunk), do: {[chunk], state}
+
+  defp forward_chunk(%{config: config, iteration: iteration} = state, %StreamChunk{
+         type: :reasoning_delta,
+         reasoning: reasoning
+       })
+       when is_binary(reasoning) do
+    emit_reasoning(config.telemetry_ctx, iteration + 1, reasoning)
+    {[], state}
+  end
+
+  defp forward_chunk(state, _chunk), do: {[], state}
+
+  @spec handle_complete_response(map(), LlmResponse.t()) :: {[StreamChunk.t()], map()}
+  defp handle_complete_response(%{config: config, messages: messages, acc: acc} = state, response) do
+    next_iteration = state.iteration + 1
+    cost_infos = acc.cost_infos ++ List.wrap(response.cost_info)
+    usage = add_usage(state.usage, response)
+
+    case LlmResponse.function_calls(response) do
+      calls when calls in [nil, []] ->
+        emit_iteration(config.telemetry_ctx, next_iteration, response.cost_info, 0, true)
+        acc = %{acc | cost_infos: cost_infos}
+        {:ok, result} = finalize(response, messages, next_iteration, acc)
+        done = done_chunk(response, usage, acc.cost_infos, result)
+
+        {[done],
+         %{state | phase: :done, status: :ok, iteration: next_iteration, usage: usage, acc: acc}}
+
+      calls ->
+        executed = execute_tool_calls(config, calls)
+
+        emit_iteration(
+          config.telemetry_ctx,
+          next_iteration,
+          response.cost_info,
+          length(calls),
+          false
+        )
+
+        acc = %{acc | cost_infos: cost_infos, function_calls: acc.function_calls ++ executed}
+
+        tool_chunks =
+          Enum.map(executed, fn call ->
+            %StreamChunk{
+              provider: response.provider,
+              type: :tool_call,
+              tool_calls: [call],
+              metadata: %{iteration: next_iteration}
+            }
+          end)
+
+        {tool_chunks,
+         %{
+           state
+           | phase: :start_turn,
+             messages: apply_tool_turn(config, messages, response, executed),
+             iteration: next_iteration,
+             usage: usage,
+             acc: acc,
+             collector: nil,
+             cont: nil
+         }}
+    end
+  end
+
+  @spec finish_stream(map()) :: :ok
+  defp finish_stream(%{config: config} = state) do
+    metadata =
+      config
+      |> run_start_metadata()
+      |> Map.merge(%{status: stop_status(state.status)})
+
+    :telemetry.execute(
+      [:llm_composer, :agent, :run, :stop],
+      %{iterations: state.iteration},
+      metadata
+    )
+
+    :ok
+  end
+
+  @spec terminate_error(map(), term()) :: {[StreamChunk.t()], map()}
+  defp terminate_error(state, reason) do
+    chunk = %StreamChunk{type: :error, metadata: %{reason: reason, status: :error}}
+    {[chunk], %{state | phase: :done, status: :error}}
+  end
+
+  @spec done_chunk(LlmResponse.t(), StreamChunk.usage(), [CostInfo.t()], Result.t()) ::
+          StreamChunk.t()
+  defp done_chunk(response, usage, cost_infos, result) do
+    %StreamChunk{
+      provider: response.provider,
+      type: :done,
+      usage: usage,
+      cost_info: StreamCollector.aggregate_cost_infos(cost_infos),
+      metadata: %{agent_result: result, status: :ok}
+    }
+  end
+
+  @spec provider_pricing_opts(config(), atom()) :: keyword()
+  defp provider_pricing_opts(config, provider) do
+    provider_mod = resolve_provider_module(config.settings, provider)
+
+    config.settings
+    |> provider_opts_for(provider_mod)
+    |> Keyword.put_new(:track_costs, config.settings.track_costs)
+  end
+
+  @spec add_usage(map(), LlmResponse.t()) :: StreamChunk.usage()
+  defp add_usage(usage, response) do
+    input = (usage[:input_tokens] || 0) + (response.input_tokens || 0)
+    output = (usage[:output_tokens] || 0) + (response.output_tokens || 0)
+
+    %{
+      input_tokens: input,
+      output_tokens: output,
+      total_tokens: input + output,
+      cached_tokens: (usage[:cached_tokens] || 0) + (response.cached_tokens || 0),
+      reasoning_tokens: (usage[:reasoning_tokens] || 0) + (response.reasoning_tokens || 0)
+    }
+  end
+
+  @spec init_puller(Enumerable.t()) :: (term() -> term())
+  defp init_puller(parsed) do
+    reducer = fn chunk, _acc -> {:suspend, chunk} end
+    fn command -> Enumerable.reduce(parsed, command, reducer) end
+  end
+
+  @spec pull((term() -> term())) :: {:chunk, StreamChunk.t(), (term() -> term())} | :done
+  defp pull(cont) do
+    case cont.({:cont, nil}) do
+      {:suspended, chunk, next_cont} -> {:chunk, chunk, next_cont}
+      {:done, _acc} -> :done
+      {:halted, _acc} -> :done
+    end
+  end
+
+  @spec stop_status(:running | :ok | :error) :: :halted | :ok | :error
+  defp stop_status(:running), do: :halted
+  defp stop_status(status), do: status
 
   # --- Tool execution ---
 
@@ -243,7 +554,15 @@ defmodule LlmComposer.Agent do
 
   @spec execute_one(config(), FunctionCall.t()) :: FunctionCall.t()
   defp execute_one(config, %FunctionCall{} = call) do
-    :telemetry.span([:llm_composer, :agent, :tool], %{name: call.name}, fn ->
+    start_metadata =
+      Map.merge(config.telemetry_ctx, %{
+        name: call.name,
+        arguments: call.arguments,
+        metadata: call.metadata,
+        id: call.id
+      })
+
+    :telemetry.span([:llm_composer, :agent, :tool], start_metadata, fn ->
       {executed, status} =
         case FunctionExecutor.execute(call, config.functions) do
           {:ok, executed} ->
@@ -257,7 +576,7 @@ defmodule LlmComposer.Agent do
             {error_call(call, reason), :error}
         end
 
-      {executed, %{name: call.name, status: status}}
+      {executed, Map.merge(config.telemetry_ctx, %{name: call.name, id: call.id, status: status})}
     end)
   end
 
@@ -278,12 +597,22 @@ defmodule LlmComposer.Agent do
 
   # --- Telemetry helpers ---
 
-  @spec emit_iteration(non_neg_integer(), CostInfo.t() | nil, non_neg_integer(), boolean()) :: :ok
-  defp emit_iteration(iteration, cost_info, tool_call_count, final?) do
+  @spec emit_iteration(map(), non_neg_integer(), CostInfo.t() | nil, non_neg_integer(), boolean()) ::
+          :ok
+  defp emit_iteration(ctx, iteration, cost_info, tool_call_count, final?) do
     :telemetry.execute(
       [:llm_composer, :agent, :iteration, :stop],
       %{tool_call_count: tool_call_count},
-      %{iteration: iteration, cost_info: cost_info, final: final?}
+      Map.merge(ctx, %{iteration: iteration, cost_info: cost_info, final: final?})
+    )
+  end
+
+  @spec emit_reasoning(map(), non_neg_integer(), String.t()) :: :ok
+  defp emit_reasoning(ctx, iteration, reasoning) do
+    :telemetry.execute(
+      [:llm_composer, :agent, :reasoning, :delta],
+      %{},
+      Map.merge(ctx, %{iteration: iteration, reasoning: reasoning})
     )
   end
 
@@ -308,11 +637,9 @@ defmodule LlmComposer.Agent do
   defp normalize_input(_settings, messages) when is_list(messages), do: messages
 
   @spec user_prompt(Settings.t(), String.t()) :: String.t()
-  defp user_prompt(%Settings{user_prompt_prefix: prefix}, message) when is_binary(prefix) do
+  defp user_prompt(%Settings{user_prompt_prefix: prefix}, message) do
     prefix <> message
   end
-
-  defp user_prompt(_settings, message), do: message
 
   @spec functions_from_settings(Settings.t()) :: [Function.t()]
   defp functions_from_settings(%Settings{providers: [{_mod, opts} | _]}) when is_list(opts) do

--- a/lib/llm_composer/agent.ex
+++ b/lib/llm_composer/agent.ex
@@ -34,8 +34,9 @@ defmodule LlmComposer.Agent do
         _other, acc -> acc
       end)
 
-  Only the `:open_ai` and `:google` providers support the streaming agent today; others yield a
-  terminal `:error` chunk with `{:streaming_agent_unsupported_provider, provider}`.
+  All providers support the streaming agent. Note that the native `:ollama` provider does not emit
+  tool-call deltas; for tool-call streaming with Ollama use the `:open_ai` provider pointed at
+  Ollama's OpenAI-compatible endpoint.
 
   ## Example
 
@@ -228,8 +229,8 @@ defmodule LlmComposer.Agent do
 
   @spec loop(config(), [Message.t()], non_neg_integer(), acc()) ::
           {:ok, Result.t()} | {:error, term()}
-  defp loop(%{max_iterations: max}, _messages, iteration, _acc) when iteration >= max do
-    {:error, :max_iterations_reached}
+  defp loop(%{max_iterations: max}, messages, iteration, acc) when iteration >= max do
+    {:error, {:max_iterations_reached, partial_result(messages, iteration, acc)}}
   end
 
   defp loop(config, messages, iteration, acc) do
@@ -293,6 +294,16 @@ defmodule LlmComposer.Agent do
     tool_msgs = FunctionCallHelpers.build_tool_result_messages(executed)
 
     messages ++ [assistant_msg | tool_msgs]
+  end
+
+  @spec partial_result([Message.t()], non_neg_integer(), acc()) :: map()
+  defp partial_result(messages, iterations, acc) do
+    %{
+      cost_infos: acc.cost_infos,
+      function_calls: acc.function_calls,
+      messages: messages,
+      iterations: iterations
+    }
   end
 
   @spec finalize(LlmResponse.t(), [Message.t()], non_neg_integer(), acc()) :: {:ok, Result.t()}
@@ -472,6 +483,20 @@ defmodule LlmComposer.Agent do
   end
 
   @spec terminate_error(map(), term()) :: {[StreamChunk.t()], map()}
+  defp terminate_error(
+         %{messages: messages, iteration: iteration, acc: acc} = state,
+         :max_iterations_reached
+       ) do
+    partial = partial_result(messages, iteration, acc)
+
+    chunk = %StreamChunk{
+      type: :error,
+      metadata: %{reason: :max_iterations_reached, partial: partial, status: :error}
+    }
+
+    {[chunk], %{state | phase: :done, status: :error}}
+  end
+
   defp terminate_error(state, reason) do
     chunk = %StreamChunk{type: :error, metadata: %{reason: reason, status: :error}}
     {[chunk], %{state | phase: :done, status: :error}}
@@ -535,8 +560,14 @@ defmodule LlmComposer.Agent do
 
   @spec execute_tool_calls(config(), [FunctionCall.t()]) :: [FunctionCall.t()]
   defp execute_tool_calls(%{tool_execution: :parallel} = config, calls) do
+    parent_metadata = Logger.metadata()
+
     calls
-    |> Task.async_stream(&execute_one(config, &1),
+    |> Task.async_stream(
+      fn call ->
+        Logger.metadata(parent_metadata)
+        execute_one(config, call)
+      end,
       ordered: true,
       timeout: config.tool_timeout,
       on_timeout: :kill_task
@@ -618,6 +649,10 @@ defmodule LlmComposer.Agent do
 
   @spec run_measurements({:ok, Result.t()} | {:error, term()}) :: map()
   defp run_measurements({:ok, %Result{iterations: iterations}}), do: %{iterations: iterations}
+
+  defp run_measurements({:error, {:max_iterations_reached, %{iterations: n}}}),
+    do: %{iterations: n}
+
   defp run_measurements({:error, _reason}), do: %{iterations: 0}
 
   @spec run_stop_metadata(map(), {:ok, Result.t()} | {:error, term()}) :: map()
@@ -642,8 +677,10 @@ defmodule LlmComposer.Agent do
   end
 
   @spec functions_from_settings(Settings.t()) :: [Function.t()]
-  defp functions_from_settings(%Settings{providers: [{_mod, opts} | _]}) when is_list(opts) do
-    Keyword.get(opts, :functions, [])
+  defp functions_from_settings(%Settings{providers: providers}) when is_list(providers) do
+    providers
+    |> Enum.flat_map(fn {_mod, opts} -> Keyword.get(opts || [], :functions, []) end)
+    |> Enum.uniq_by(& &1.name)
   end
 
   defp functions_from_settings(%Settings{provider_opts: opts}) when is_list(opts) do

--- a/lib/llm_composer/agent/stream_collector.ex
+++ b/lib/llm_composer/agent/stream_collector.ex
@@ -8,10 +8,16 @@ defmodule LlmComposer.Agent.StreamCollector do
   - **OpenAI / OpenRouter** send `:tool_call_delta` chunks whose `tool_calls` are raw maps keyed by
     `"index"`, with the `function.arguments` JSON split across several chunks. They must be grouped
     by index and concatenated.
+  - **OpenAI Responses** sends a `"function_call_started"` map (carries `"call_id"` and `"name"`)
+    followed by one or more `"function_call_arguments_delta"` maps (carry `"call_id"` and
+    `"arguments_delta"`). Fragments are grouped by `"call_id"` and concatenated in arrival order.
   - **Google** sends already-complete `LlmComposer.FunctionCall` structs (one per chunk).
   - **Bedrock** sends two event types per tool call: a start event with `"toolUseId"` and `"name"`,
     followed by one or more delta events that carry only `"inputJson"` fragments. Fragments are
     grouped by `"toolUseId"` and concatenated in arrival order.
+  - **Ollama** (native provider) does not emit tool-call deltas in its streaming format; text
+    streaming works. For tool-call streaming with Ollama, use the `:open_ai` provider pointed at
+    Ollama's OpenAI-compatible endpoint.
 
   This collector hides those differences. Feed every chunk of a turn through `add/2`, then call
   `tool_turn?/1` to know whether the model requested tools, and `to_llm_response/1` to obtain a
@@ -26,7 +32,7 @@ defmodule LlmComposer.Agent.StreamCollector do
   alias LlmComposer.Message
   alias LlmComposer.StreamChunk
 
-  @supported_providers [:open_ai, :open_router, :google, :bedrock]
+  @supported_providers [:open_ai, :open_router, :open_ai_responses, :google, :bedrock, :ollama]
 
   @type t() :: %__MODULE__{
           provider: atom(),
@@ -132,6 +138,19 @@ defmodule LlmComposer.Agent.StreamCollector do
       %FunctionCall{id: id, name: name, arguments: args, type: "function"}
     end)
   end
+
+  def to_function_calls(%__MODULE__{
+        provider: :open_ai_responses,
+        tool_fragments: fragments,
+        tool_id_sequence: order
+      }) do
+    Enum.map(order, fn call_id ->
+      %{"call_id" => id, "name" => name, "arguments" => args} = Map.fetch!(fragments, call_id)
+      %FunctionCall{id: id, name: name, arguments: args, type: "function"}
+    end)
+  end
+
+  def to_function_calls(%__MODULE__{}), do: []
 
   @doc """
   Builds a synthetic `LlmComposer.LlmResponse` equivalent to a non-streaming response for the turn.
@@ -246,6 +265,40 @@ defmodule LlmComposer.Agent.StreamCollector do
           end)
 
         %{acc | tool_fragments: fragments}
+    end)
+  end
+
+  defp merge_tool_calls(%__MODULE__{provider: :open_ai_responses} = collector, tool_calls) do
+    Enum.reduce(tool_calls, collector, fn
+      %{"type" => "function_call_started", "call_id" => call_id, "name" => name}, acc ->
+        fragment = %{"call_id" => call_id, "name" => name, "arguments" => ""}
+
+        %{
+          acc
+          | tool_fragments: Map.put(acc.tool_fragments, call_id, fragment),
+            tool_id_sequence: acc.tool_id_sequence ++ [call_id],
+            current_tool_id: call_id
+        }
+
+      %{
+        "type" => "function_call_arguments_delta",
+        "call_id" => call_id,
+        "arguments_delta" => delta
+      },
+      acc
+      when is_binary(delta) ->
+        # The API delta event omits call_id; fall back to the most recently started call.
+        target_id = call_id || acc.current_tool_id
+
+        fragments =
+          Map.update!(acc.tool_fragments, target_id, fn f ->
+            Map.update(f, "arguments", delta, &(&1 <> delta))
+          end)
+
+        %{acc | tool_fragments: fragments}
+
+      _other, acc ->
+        acc
     end)
   end
 

--- a/lib/llm_composer/agent/stream_collector.ex
+++ b/lib/llm_composer/agent/stream_collector.ex
@@ -1,0 +1,293 @@
+defmodule LlmComposer.Agent.StreamCollector do
+  @moduledoc """
+  Accumulates the `LlmComposer.StreamChunk`s of a single agent turn and reassembles them into a
+  synthetic `LlmComposer.LlmResponse`.
+
+  Streaming providers emit tool calls incrementally and in provider-specific shapes:
+
+  - **OpenAI / OpenRouter** send `:tool_call_delta` chunks whose `tool_calls` are raw maps keyed by
+    `"index"`, with the `function.arguments` JSON split across several chunks. They must be grouped
+    by index and concatenated.
+  - **Google** sends already-complete `LlmComposer.FunctionCall` structs (one per chunk).
+  - **Bedrock** sends two event types per tool call: a start event with `"toolUseId"` and `"name"`,
+    followed by one or more delta events that carry only `"inputJson"` fragments. Fragments are
+    grouped by `"toolUseId"` and concatenated in arrival order.
+
+  This collector hides those differences. Feed every chunk of a turn through `add/2`, then call
+  `tool_turn?/1` to know whether the model requested tools, and `to_llm_response/1` to obtain a
+  response shaped exactly like a non-streaming one (so the rest of `LlmComposer.Agent` can reuse the
+  synchronous loop unchanged).
+  """
+
+  alias LlmComposer.CostInfo
+  alias LlmComposer.FunctionCall
+  alias LlmComposer.FunctionCallExtractors
+  alias LlmComposer.LlmResponse
+  alias LlmComposer.Message
+  alias LlmComposer.StreamChunk
+
+  @supported_providers [:open_ai, :open_router, :google, :bedrock]
+
+  @type t() :: %__MODULE__{
+          provider: atom(),
+          text: iodata(),
+          reasoning: iodata(),
+          tool_fragments: %{optional(non_neg_integer() | String.t()) => map()},
+          tool_id_sequence: [String.t()],
+          current_tool_id: String.t() | nil,
+          function_calls: [FunctionCall.t()],
+          saw_tool_call: boolean(),
+          usage: StreamChunk.usage() | nil,
+          cost_info: CostInfo.t() | nil
+        }
+
+  defstruct provider: nil,
+            text: [],
+            reasoning: [],
+            tool_fragments: %{},
+            tool_id_sequence: [],
+            current_tool_id: nil,
+            function_calls: [],
+            saw_tool_call: false,
+            usage: nil,
+            cost_info: nil
+
+  @doc """
+  Creates a collector for the given provider.
+
+  Raises `ArgumentError` for providers that are not yet supported by the streaming agent.
+  """
+  @spec new(atom()) :: t()
+  def new(provider) when provider in @supported_providers do
+    %__MODULE__{provider: provider}
+  end
+
+  def new(provider) do
+    raise ArgumentError,
+          "streaming agent does not support provider #{inspect(provider)} yet " <>
+            "(supported: #{inspect(@supported_providers)})"
+  end
+
+  @doc """
+  Accumulates a single `LlmComposer.StreamChunk` into the collector.
+  """
+  @spec add(t(), StreamChunk.t()) :: t()
+  def add(%__MODULE__{} = collector, %StreamChunk{type: :text_delta, text: text})
+      when is_binary(text) do
+    %{collector | text: [collector.text, text]}
+  end
+
+  def add(%__MODULE__{} = collector, %StreamChunk{type: :reasoning_delta, reasoning: reasoning})
+      when is_binary(reasoning) do
+    %{collector | reasoning: [collector.reasoning, reasoning]}
+  end
+
+  def add(%__MODULE__{} = collector, %StreamChunk{type: :tool_call_delta, tool_calls: tool_calls})
+      when is_list(tool_calls) do
+    collector
+    |> Map.put(:saw_tool_call, true)
+    |> merge_tool_calls(tool_calls)
+  end
+
+  def add(%__MODULE__{} = collector, %StreamChunk{} = chunk) do
+    collector
+    |> maybe_put_usage(chunk.usage)
+    |> maybe_put_cost_info(chunk.cost_info)
+  end
+
+  @doc """
+  Returns `true` once any tool-call delta has been accumulated.
+  """
+  @spec tool_turn?(t()) :: boolean()
+  def tool_turn?(%__MODULE__{saw_tool_call: saw_tool_call}), do: saw_tool_call
+
+  @doc """
+  Returns the accumulated reasoning text, or `nil` when none was streamed.
+  """
+  @spec reasoning(t()) :: String.t() | nil
+  def reasoning(%__MODULE__{reasoning: reasoning}), do: blank_to_nil(reasoning)
+
+  @doc """
+  Finalizes the accumulated tool-call deltas into complete `LlmComposer.FunctionCall` structs.
+  """
+  @spec to_function_calls(t()) :: [FunctionCall.t()]
+  def to_function_calls(%__MODULE__{provider: :google, function_calls: calls}), do: calls
+
+  def to_function_calls(%__MODULE__{provider: p, tool_fragments: fragments})
+      when p in [:open_ai, :open_router] do
+    fragments
+    |> Enum.sort_by(fn {index, _fragment} -> index end)
+    |> Enum.map(fn {_index, fragment} -> fragment end)
+    |> then(&FunctionCallExtractors.from_tool_calls(%{"tool_calls" => &1}))
+    |> List.wrap()
+  end
+
+  def to_function_calls(%__MODULE__{
+        provider: :bedrock,
+        tool_fragments: fragments,
+        tool_id_sequence: order
+      }) do
+    Enum.map(order, fn tool_id ->
+      %{"toolUseId" => id, "name" => name, "inputJson" => args} = Map.fetch!(fragments, tool_id)
+      %FunctionCall{id: id, name: name, arguments: args, type: "function"}
+    end)
+  end
+
+  @doc """
+  Builds a synthetic `LlmComposer.LlmResponse` equivalent to a non-streaming response for the turn.
+
+  The returned response has an `:assistant` `main_response` carrying the accumulated text, reasoning
+  and reassembled function calls, plus token usage and cost info captured from the stream.
+  """
+  @spec to_llm_response(t()) :: LlmResponse.t()
+  def to_llm_response(%__MODULE__{} = collector) do
+    usage = collector.usage || %{}
+    function_calls = to_function_calls(collector)
+
+    main_response = %Message{
+      type: :assistant,
+      content: blank_to_nil(collector.text),
+      function_calls: function_calls,
+      reasoning: blank_to_nil(collector.reasoning),
+      metadata: %{}
+    }
+
+    LlmResponse.new(%{
+      provider: collector.provider,
+      status: :ok,
+      main_response: main_response,
+      input_tokens: Map.get(usage, :input_tokens),
+      output_tokens: Map.get(usage, :output_tokens),
+      cached_tokens: Map.get(usage, :cached_tokens),
+      reasoning_tokens: Map.get(usage, :reasoning_tokens),
+      cost_info: collector.cost_info
+    })
+  end
+
+  @doc """
+  Sums a list of per-turn `LlmComposer.CostInfo` into a single aggregate, or `nil` when empty.
+
+  Token counts are added and `Decimal` cost fields are summed. `provider_name`, `provider_model`
+  and `currency` are taken from the first entry (a run may span models).
+  """
+  @spec aggregate_cost_infos([CostInfo.t()]) :: CostInfo.t() | nil
+  def aggregate_cost_infos([]), do: nil
+
+  def aggregate_cost_infos([first | _] = cost_infos) do
+    initial = %CostInfo{
+      provider_name: first.provider_name,
+      provider_model: first.provider_model,
+      currency: first.currency,
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+      cached_tokens: 0,
+      input_cost: nil,
+      output_cost: nil,
+      total_cost: nil,
+      metadata: %{aggregated: true, count: length(cost_infos)}
+    }
+
+    Enum.reduce(cost_infos, initial, fn cost_info, acc ->
+      %CostInfo{
+        acc
+        | input_tokens: acc.input_tokens + (cost_info.input_tokens || 0),
+          output_tokens: acc.output_tokens + (cost_info.output_tokens || 0),
+          total_tokens: acc.total_tokens + (cost_info.total_tokens || 0),
+          cached_tokens: acc.cached_tokens + (cost_info.cached_tokens || 0),
+          input_cost: add_decimal(acc.input_cost, cost_info.input_cost),
+          output_cost: add_decimal(acc.output_cost, cost_info.output_cost),
+          total_cost: add_decimal(acc.total_cost, cost_info.total_cost)
+      }
+    end)
+  end
+
+  # Private functions
+
+  @spec merge_tool_calls(t(), [map() | FunctionCall.t()]) :: t()
+  defp merge_tool_calls(%__MODULE__{provider: :google} = collector, tool_calls) do
+    new_calls = Enum.filter(tool_calls, &match?(%FunctionCall{}, &1))
+    %{collector | function_calls: collector.function_calls ++ new_calls}
+  end
+
+  defp merge_tool_calls(%__MODULE__{provider: p} = collector, tool_calls)
+       when p in [:open_ai, :open_router] do
+    fragments =
+      Enum.reduce(tool_calls, collector.tool_fragments, fn raw, acc ->
+        index = Map.get(raw, "index", map_size(acc))
+        Map.update(acc, index, raw, &merge_fragment(&1, raw))
+      end)
+
+    %{collector | tool_fragments: fragments}
+  end
+
+  defp merge_tool_calls(%__MODULE__{provider: :bedrock} = collector, tool_calls) do
+    Enum.reduce(tool_calls, collector, fn
+      %{"toolUseId" => tool_id, "name" => name} = raw, acc ->
+        fragment = %{
+          "toolUseId" => tool_id,
+          "name" => name,
+          "inputJson" => Map.get(raw, "inputJson", "")
+        }
+
+        %{
+          acc
+          | tool_fragments: Map.put(acc.tool_fragments, tool_id, fragment),
+            tool_id_sequence: acc.tool_id_sequence ++ [tool_id],
+            current_tool_id: tool_id
+        }
+
+      %{"inputJson" => input}, acc when is_binary(input) ->
+        tool_id = acc.current_tool_id
+
+        fragments =
+          Map.update!(acc.tool_fragments, tool_id, fn f ->
+            Map.update(f, "inputJson", input, &(&1 <> input))
+          end)
+
+        %{acc | tool_fragments: fragments}
+    end)
+  end
+
+  @spec merge_fragment(map(), map()) :: map()
+  defp merge_fragment(existing, incoming) do
+    Map.merge(existing, incoming, fn
+      "function", existing_fun, incoming_fun -> merge_function(existing_fun, incoming_fun)
+      _key, existing_val, incoming_val -> existing_val || incoming_val
+    end)
+  end
+
+  @spec merge_function(map(), map()) :: map()
+  defp merge_function(existing_fun, incoming_fun) do
+    existing_args = Map.get(existing_fun, "arguments", "")
+    incoming_args = Map.get(incoming_fun, "arguments", "")
+
+    existing_fun
+    |> Map.merge(incoming_fun, fn _key, existing_val, incoming_val ->
+      existing_val || incoming_val
+    end)
+    |> Map.put("arguments", (existing_args || "") <> (incoming_args || ""))
+  end
+
+  @spec maybe_put_usage(t(), StreamChunk.usage() | nil) :: t()
+  defp maybe_put_usage(collector, nil), do: collector
+  defp maybe_put_usage(collector, usage), do: %{collector | usage: usage}
+
+  @spec maybe_put_cost_info(t(), CostInfo.t() | nil) :: t()
+  defp maybe_put_cost_info(collector, nil), do: collector
+  defp maybe_put_cost_info(collector, cost_info), do: %{collector | cost_info: cost_info}
+
+  @spec blank_to_nil(iodata()) :: String.t() | nil
+  defp blank_to_nil(iodata) do
+    case IO.iodata_to_binary(iodata) do
+      "" -> nil
+      binary -> binary
+    end
+  end
+
+  @spec add_decimal(Decimal.t() | nil, Decimal.t() | nil) :: Decimal.t() | nil
+  defp add_decimal(nil, nil), do: nil
+  defp add_decimal(nil, value), do: value
+  defp add_decimal(value, nil), do: value
+  defp add_decimal(left, right), do: Decimal.add(left, right)
+end

--- a/lib/llm_composer/function_call_helpers.ex
+++ b/lib/llm_composer/function_call_helpers.ex
@@ -9,6 +9,7 @@ defmodule LlmComposer.FunctionCallHelpers do
   behavior.
   """
 
+  alias LlmComposer.Helpers
   alias LlmComposer.LlmResponse
   alias LlmComposer.Message
 
@@ -51,9 +52,18 @@ defmodule LlmComposer.FunctionCallHelpers do
     Enum.map(executed_calls, fn call ->
       %Message{
         type: :tool_result,
-        content: to_string(call.result),
+        content: result_to_content(call.result),
         metadata: %{"tool_call_id" => call.id}
       }
     end)
+  end
+
+  @spec result_to_content(term()) :: String.t()
+  defp result_to_content(result) when is_binary(result), do: result
+
+  defp result_to_content(result) do
+    Helpers.json_engine().encode!(result)
+  rescue
+    _ -> inspect(result)
   end
 end

--- a/lib/llm_composer/providers/open_ai_responses.ex
+++ b/lib/llm_composer/providers/open_ai_responses.ex
@@ -82,7 +82,7 @@ defmodule LlmComposer.Providers.OpenAIResponses do
 
   defp handle_response({:ok, resp}) do
     Logger.warning(
-      "[open_ai_responses] non-200 response (status=#{Map.get(resp, :status, :unknown)})"
+      "[open_ai_responses] non-200 response (status=#{Map.get(resp, :status, :unknown)}) body=#{inspect(Map.get(resp, :body))}"
     )
 
     {:error, resp}
@@ -273,7 +273,7 @@ defmodule LlmComposer.Providers.OpenAIResponses do
         type: "function",
         name: function.name,
         description: function.description,
-        parameters: function.schema,
+        parameters: Map.put_new(function.schema, "additionalProperties", false),
         strict: true
       }
     end)

--- a/lib/llm_composer/providers_runner.ex
+++ b/lib/llm_composer/providers_runner.ex
@@ -83,6 +83,7 @@ defmodule LlmComposer.ProvidersRunner do
           {{:ok, any()} | {:error, term()}, map()}
   defp run_provider(provider, messages, system_msg, provider_opts) do
     provider_name = provider.name()
+    # Intentional: telemetry must not raise on misconfiguration — nil is acceptable here.
     model = Keyword.get(provider_opts, :model)
 
     :telemetry.span(

--- a/lib/llm_composer/stream_chunk.ex
+++ b/lib/llm_composer/stream_chunk.ex
@@ -29,7 +29,14 @@ defmodule LlmComposer.StreamChunk do
   @type t() :: %__MODULE__{
           provider: atom(),
           type:
-            :text_delta | :reasoning_delta | :tool_call_delta | :usage | :done | :error | :unknown,
+            :text_delta
+            | :reasoning_delta
+            | :tool_call_delta
+            | :tool_call
+            | :usage
+            | :done
+            | :error
+            | :unknown,
           text: String.t() | nil,
           reasoning: String.t() | nil,
           reasoning_details: list() | nil,

--- a/test/llm_composer/agent/stream_collector_test.exs
+++ b/test/llm_composer/agent/stream_collector_test.exs
@@ -1,0 +1,301 @@
+defmodule LlmComposer.Agent.StreamCollectorTest do
+  use ExUnit.Case, async: true
+
+  alias LlmComposer.Agent.StreamCollector
+  alias LlmComposer.CostInfo
+  alias LlmComposer.FunctionCall
+  alias LlmComposer.LlmResponse
+  alias LlmComposer.StreamChunk
+
+  describe "OpenAI tool-call reassembly" do
+    test "merges fragmented arguments by index into a single FunctionCall" do
+      chunks = [
+        tool_chunk([
+          %{
+            "index" => 0,
+            "id" => "call_1",
+            "type" => "function",
+            "function" => %{"name" => "get_weather", "arguments" => ""}
+          }
+        ]),
+        tool_chunk([%{"index" => 0, "function" => %{"arguments" => "{\"loc"}}]),
+        tool_chunk([%{"index" => 0, "function" => %{"arguments" => "ation\":\"Paris\"}"}}])
+      ]
+
+      collector = collect(:open_ai, chunks)
+
+      assert StreamCollector.tool_turn?(collector)
+
+      assert [%FunctionCall{id: "call_1", name: "get_weather", arguments: args, type: "function"}] =
+               StreamCollector.to_function_calls(collector)
+
+      assert args == "{\"location\":\"Paris\"}"
+    end
+
+    test "keeps multiple parallel tool calls separated by index" do
+      chunks = [
+        tool_chunk([
+          %{
+            "index" => 0,
+            "id" => "a",
+            "type" => "function",
+            "function" => %{"name" => "f", "arguments" => "{\"x\":1}"}
+          },
+          %{
+            "index" => 1,
+            "id" => "b",
+            "type" => "function",
+            "function" => %{"name" => "g", "arguments" => "{\"y\":2}"}
+          }
+        ])
+      ]
+
+      collector = collect(:open_ai, chunks)
+
+      assert [%FunctionCall{id: "a", name: "f"}, %FunctionCall{id: "b", name: "g"}] =
+               StreamCollector.to_function_calls(collector)
+    end
+  end
+
+  describe "Google tool-call collection" do
+    test "collects already-complete FunctionCall structs" do
+      call = %FunctionCall{
+        id: "http_client",
+        name: "http_client",
+        arguments: "{}",
+        type: "function"
+      }
+
+      chunk = %StreamChunk{provider: :google, type: :tool_call_delta, tool_calls: [call]}
+
+      collector = collect(:google, [chunk])
+
+      assert StreamCollector.tool_turn?(collector)
+      assert StreamCollector.to_function_calls(collector) == [call]
+    end
+  end
+
+  describe "to_llm_response/1" do
+    test "builds a final assistant response from text and usage" do
+      collector =
+        collect(:open_ai, [
+          text_chunk("Hello "),
+          text_chunk("world"),
+          usage_chunk(%{input_tokens: 10, output_tokens: 4})
+        ])
+
+      assert %LlmResponse{
+               provider: :open_ai,
+               status: :ok,
+               input_tokens: 10,
+               output_tokens: 4,
+               main_response: %{type: :assistant, content: "Hello world", function_calls: []}
+             } = StreamCollector.to_llm_response(collector)
+    end
+
+    test "exposes reassembled tool calls as the response function_calls" do
+      collector =
+        collect(:open_ai, [
+          tool_chunk([
+            %{
+              "index" => 0,
+              "id" => "c",
+              "type" => "function",
+              "function" => %{"name" => "f", "arguments" => "{}"}
+            }
+          ])
+        ])
+
+      assert [%FunctionCall{name: "f"}] =
+               StreamCollector.to_llm_response(collector).main_response.function_calls
+    end
+  end
+
+  describe "aggregate_cost_infos/1" do
+    test "returns nil for an empty list" do
+      assert StreamCollector.aggregate_cost_infos([]) == nil
+    end
+
+    test "sums tokens and Decimal costs across turns" do
+      a = cost_info(10, 5, "0.10")
+      b = cost_info(20, 8, "0.20")
+
+      assert %CostInfo{input_tokens: 30, output_tokens: 13, total_tokens: 43, total_cost: total} =
+               StreamCollector.aggregate_cost_infos([a, b])
+
+      assert Decimal.equal?(total, Decimal.new("0.30"))
+    end
+  end
+
+  describe "OpenRouter tool-call reassembly" do
+    test "merges fragmented arguments by index (same format as OpenAI)" do
+      chunks = [
+        %StreamChunk{
+          provider: :open_router,
+          type: :tool_call_delta,
+          tool_calls: [
+            %{
+              "index" => 0,
+              "id" => "call_or_1",
+              "type" => "function",
+              "function" => %{"name" => "get_weather", "arguments" => ""}
+            }
+          ]
+        },
+        %StreamChunk{
+          provider: :open_router,
+          type: :tool_call_delta,
+          tool_calls: [%{"index" => 0, "function" => %{"arguments" => "{\"city\":"}}]
+        },
+        %StreamChunk{
+          provider: :open_router,
+          type: :tool_call_delta,
+          tool_calls: [%{"index" => 0, "function" => %{"arguments" => "\"Paris\"}"}}]
+        }
+      ]
+
+      collector = collect(:open_router, chunks)
+
+      assert StreamCollector.tool_turn?(collector)
+
+      assert [
+               %FunctionCall{
+                 id: "call_or_1",
+                 name: "get_weather",
+                 arguments: "{\"city\":\"Paris\"}",
+                 type: "function"
+               }
+             ] = StreamCollector.to_function_calls(collector)
+    end
+  end
+
+  describe "Bedrock tool-call reassembly" do
+    test "merges a start chunk and inputJson deltas into a FunctionCall" do
+      chunks = [
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"toolUseId" => "bedrock_1", "name" => "calculator", "inputJson" => ""}]
+        },
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"inputJson" => "{\"expression\":"}]
+        },
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"inputJson" => "\"2 + 3\"}"}]
+        }
+      ]
+
+      collector = collect(:bedrock, chunks)
+
+      assert StreamCollector.tool_turn?(collector)
+
+      assert [
+               %FunctionCall{
+                 id: "bedrock_1",
+                 name: "calculator",
+                 arguments: "{\"expression\":\"2 + 3\"}",
+                 type: "function"
+               }
+             ] = StreamCollector.to_function_calls(collector)
+    end
+
+    test "preserves insertion order for multiple sequential tool calls" do
+      chunks = [
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"toolUseId" => "id_a", "name" => "tool_a", "inputJson" => ""}]
+        },
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"inputJson" => "{\"x\":1}"}]
+        },
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"toolUseId" => "id_b", "name" => "tool_b", "inputJson" => ""}]
+        },
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"inputJson" => "{\"y\":2}"}]
+        }
+      ]
+
+      collector = collect(:bedrock, chunks)
+
+      assert [
+               %FunctionCall{id: "id_a", name: "tool_a", arguments: "{\"x\":1}"},
+               %FunctionCall{id: "id_b", name: "tool_b", arguments: "{\"y\":2}"}
+             ] = StreamCollector.to_function_calls(collector)
+    end
+
+    test "to_llm_response/1 exposes assembled Bedrock tool calls" do
+      chunks = [
+        %StreamChunk{
+          provider: :bedrock,
+          type: :tool_call_delta,
+          tool_calls: [%{"toolUseId" => "bid_1", "name" => "lookup", "inputJson" => "{}"}]
+        },
+        %StreamChunk{
+          provider: :bedrock,
+          type: :usage,
+          usage: %{input_tokens: 8, output_tokens: 3}
+        }
+      ]
+
+      collector = collect(:bedrock, chunks)
+
+      assert %LlmResponse{
+               provider: :bedrock,
+               status: :ok,
+               input_tokens: 8,
+               output_tokens: 3,
+               main_response: %{
+                 type: :assistant,
+                 function_calls: [%FunctionCall{id: "bid_1", name: "lookup", arguments: "{}"}]
+               }
+             } = StreamCollector.to_llm_response(collector)
+    end
+  end
+
+  test "new/1 raises for unsupported providers" do
+    assert_raise ArgumentError, fn -> StreamCollector.new(:ollama) end
+  end
+
+  # --- Helpers ---
+
+  defp collect(provider, chunks) do
+    Enum.reduce(chunks, StreamCollector.new(provider), &StreamCollector.add(&2, &1))
+  end
+
+  defp tool_chunk(tool_calls) do
+    %StreamChunk{provider: :open_ai, type: :tool_call_delta, tool_calls: tool_calls}
+  end
+
+  defp text_chunk(text) do
+    %StreamChunk{provider: :open_ai, type: :text_delta, text: text}
+  end
+
+  defp usage_chunk(usage) do
+    %StreamChunk{provider: :open_ai, type: :usage, usage: usage}
+  end
+
+  defp cost_info(input_tokens, output_tokens, total_cost) do
+    %CostInfo{
+      provider_name: :open_ai,
+      provider_model: "gpt-4.1-mini",
+      currency: "USD",
+      input_tokens: input_tokens,
+      output_tokens: output_tokens,
+      total_tokens: input_tokens + output_tokens,
+      cached_tokens: 0,
+      total_cost: Decimal.new(total_cost)
+    }
+  end
+end

--- a/test/llm_composer/agent/stream_collector_test.exs
+++ b/test/llm_composer/agent/stream_collector_test.exs
@@ -265,7 +265,7 @@ defmodule LlmComposer.Agent.StreamCollectorTest do
   end
 
   test "new/1 raises for unsupported providers" do
-    assert_raise ArgumentError, fn -> StreamCollector.new(:ollama) end
+    assert_raise ArgumentError, fn -> StreamCollector.new(:unknown_provider) end
   end
 
   # --- Helpers ---

--- a/test/llm_composer/agent_test.exs
+++ b/test/llm_composer/agent_test.exs
@@ -86,8 +86,11 @@ defmodule LlmComposer.AgentTest do
 
     settings = settings(bypass)
 
-    assert {:error, :max_iterations_reached} =
+    assert {:error, {:max_iterations_reached, partial}} =
              Agent.run(settings, "loop forever", max_iterations: 2)
+
+    assert partial.iterations == 2
+    assert partial.function_calls != []
   end
 
   test "feeds tool execution errors back to the model instead of aborting", %{bypass: bypass} do

--- a/test/llm_composer/agent_test.exs
+++ b/test/llm_composer/agent_test.exs
@@ -4,9 +4,11 @@ defmodule LlmComposer.AgentTest do
   alias LlmComposer.Agent
   alias LlmComposer.Agent.Result
   alias LlmComposer.Function
+  alias LlmComposer.FunctionCall
   alias LlmComposer.Message
   alias LlmComposer.Providers.OpenAI
   alias LlmComposer.Settings
+  alias LlmComposer.StreamChunk
 
   setup do
     bypass = Bypass.open()
@@ -142,14 +144,161 @@ defmodule LlmComposer.AgentTest do
     assert [%{id: "call_a", result: 5}, %{id: "call_b", result: 20}] = result.function_calls
   end
 
-  test "rejects streaming settings without making a request" do
-    settings = %Settings{
-      providers: [{OpenAI, [model: "gpt-4.1-mini", api_key: "k", url: "http://localhost:0/"]}],
-      system_prompt: "You are a helpful assistant",
-      stream_response: true
-    }
+  test "streams the final answer after a tool round (answer stream is text-only)", %{
+    bypass: bypass
+  } do
+    Bypass.expect(bypass, "POST", "/chat/completions", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      request = Jason.decode!(body)
 
-    assert {:error, :streaming_not_supported} = Agent.run(settings, "hi")
+      if has_tool_message?(request) do
+        send_sse(conn, text_stream(["The result ", "is 5."], {12, 6}))
+      else
+        send_sse(
+          conn,
+          tool_call_stream([{0, "call_1", "calculator", ~s({"expression":"2 + 3"})}], {10, 5})
+        )
+      end
+    end)
+
+    settings = stream_settings(bypass)
+    {:ok, stream} = Agent.run(settings, "How much is 2 + 3?")
+    outcome = consume(stream)
+
+    # raw deltas are still suppressed; assembled :tool_call chunks appear instead
+    assert :tool_call_delta not in outcome.types
+    assert :tool_call in outcome.types
+    assert [%FunctionCall{name: "calculator", id: "call_1", result: 5}] = outcome.tool_calls
+    assert outcome.text == "The result is 5."
+
+    assert %StreamChunk{type: :done, metadata: %{agent_result: %Result{} = result}} = outcome.done
+    assert result.iterations == 2
+    assert result.response.main_response.content == "The result is 5."
+    assert [%{name: "calculator", id: "call_1", result: 5}] = result.function_calls
+
+    # cumulative usage + cost on the terminal chunk
+    assert outcome.done.usage.input_tokens == 22
+    assert outcome.done.usage.output_tokens == 11
+    assert length(result.cost_infos) == 2
+  end
+
+  test "streams immediately when the model needs no tools", %{bypass: bypass} do
+    Bypass.expect_once(bypass, "POST", "/chat/completions", fn conn ->
+      send_sse(conn, text_stream(["Hello ", "there!"], {7, 3}))
+    end)
+
+    settings = stream_settings(bypass)
+    {:ok, stream} = Agent.run(settings, "hi")
+    outcome = consume(stream)
+
+    assert outcome.text == "Hello there!"
+    assert %StreamChunk{type: :done, metadata: %{agent_result: result}} = outcome.done
+    assert result.iterations == 1
+    assert result.function_calls == []
+  end
+
+  test "reassembles multiple parallel tool calls while streaming", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/chat/completions", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      request = Jason.decode!(body)
+
+      if has_tool_message?(request) do
+        send_sse(conn, text_stream(["Both done."], {15, 5}))
+      else
+        send_sse(
+          conn,
+          tool_call_stream(
+            [
+              {0, "call_a", "calculator", ~s({"expression":"2 + 3"})},
+              {1, "call_b", "calculator", ~s({"expression":"10 * 2"})}
+            ],
+            {12, 8}
+          )
+        )
+      end
+    end)
+
+    settings = stream_settings(bypass)
+    {:ok, stream} = Agent.run(settings, "do two calcs", tool_execution: :parallel)
+    outcome = consume(stream)
+
+    assert outcome.text == "Both done."
+    assert %StreamChunk{type: :done, metadata: %{agent_result: result}} = outcome.done
+    assert [%{id: "call_a", result: 5}, %{id: "call_b", result: 20}] = result.function_calls
+    assert length(outcome.tool_calls) == 2
+    assert Enum.find(outcome.tool_calls, &(&1.id == "call_a"))
+    assert Enum.find(outcome.tool_calls, &(&1.id == "call_b"))
+  end
+
+  test "emits a terminal error chunk when max_iterations is exceeded", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/chat/completions", fn conn ->
+      send_sse(
+        conn,
+        tool_call_stream([{0, "call_x", "calculator", ~s({"expression":"1 + 1"})}], {5, 5})
+      )
+    end)
+
+    settings = stream_settings(bypass)
+    {:ok, stream} = Agent.run(settings, "loop forever", max_iterations: 1)
+    outcome = consume(stream)
+
+    assert %StreamChunk{type: :error, metadata: %{reason: :max_iterations_reached}} = outcome.done
+  end
+
+  test "exposes tool, reasoning and run telemetry scoped by telemetry_metadata", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/chat/completions", fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      request = Jason.decode!(body)
+
+      if has_tool_message?(request) do
+        send_sse(conn, text_stream(["ok"], {12, 6}))
+      else
+        send_sse(
+          conn,
+          tool_call_stream([{0, "call_1", "calculator", ~s({"expression":"2 + 3"})}], {10, 5},
+            reasoning: "let me compute"
+          )
+        )
+      end
+    end)
+
+    cid = System.unique_integer([:positive])
+    test_pid = self()
+    handler_id = "agent-stream-telemetry-#{cid}"
+
+    :telemetry.attach_many(
+      handler_id,
+      [
+        [:llm_composer, :agent, :run, :stop],
+        [:llm_composer, :agent, :tool, :start],
+        [:llm_composer, :agent, :reasoning, :delta]
+      ],
+      fn event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    settings = stream_settings(bypass)
+    {:ok, stream} = Agent.run(settings, "compute", telemetry_metadata: %{conversation_id: cid})
+
+    _outcome = consume(stream)
+
+    assert_receive {:telemetry, [:llm_composer, :agent, :tool, :start], _meas, tool_meta}
+    assert tool_meta.name == "calculator"
+    assert tool_meta.arguments == ~s({"expression":"2 + 3"})
+    assert tool_meta.id == "call_1"
+    assert is_map(tool_meta.metadata)
+    assert tool_meta.conversation_id == cid
+    assert is_integer(tool_meta.run_id)
+
+    assert_receive {:telemetry, [:llm_composer, :agent, :reasoning, :delta], _m,
+                    %{reasoning: "let me compute", conversation_id: ^cid}}
+
+    assert_receive {:telemetry, [:llm_composer, :agent, :run, :stop], %{iterations: 2},
+                    %{status: :ok, conversation_id: ^cid}}
   end
 
   test "emits run telemetry with iteration count", %{bypass: bypass} do
@@ -280,4 +429,101 @@ defmodule LlmComposer.AgentTest do
   end
 
   defp endpoint_url(port), do: "http://localhost:#{port}/"
+
+  # --- Streaming helpers ---
+
+  defp stream_settings(bypass), do: %{settings(bypass) | stream_response: true}
+
+  defp send_sse(conn, events) do
+    conn = Plug.Conn.send_chunked(conn, 200)
+
+    Enum.reduce(events, conn, fn data, conn ->
+      {:ok, conn} = Plug.Conn.chunk(conn, data)
+      conn
+    end)
+  end
+
+  defp sse(payload), do: "data: " <> Jason.encode!(payload) <> "\n\n"
+
+  defp stream_event(delta, finish_reason \\ nil) do
+    sse(%{
+      "model" => "gpt-4.1-mini",
+      "choices" => [%{"index" => 0, "delta" => delta, "finish_reason" => finish_reason}]
+    })
+  end
+
+  defp usage_event({prompt, completion}) do
+    sse(%{
+      "model" => "gpt-4.1-mini",
+      "choices" => [],
+      "usage" => %{
+        "prompt_tokens" => prompt,
+        "completion_tokens" => completion,
+        "total_tokens" => prompt + completion
+      }
+    })
+  end
+
+  # calls: list of {index, id, name, arguments_json}. arguments are split into two SSE fragments
+  # so the test exercises the reassembler's concatenation-by-index logic.
+  defp tool_call_stream(calls, usage, opts \\ []) do
+    reasoning_events =
+      case Keyword.get(opts, :reasoning) do
+        nil -> []
+        text -> [stream_event(%{"reasoning" => text})]
+      end
+
+    call_events =
+      Enum.flat_map(calls, fn {index, id, name, arguments} ->
+        {head, tail} = String.split_at(arguments, div(String.length(arguments), 2))
+
+        [
+          stream_event(%{
+            "tool_calls" => [
+              %{
+                "index" => index,
+                "id" => id,
+                "type" => "function",
+                "function" => %{"name" => name, "arguments" => ""}
+              }
+            ]
+          }),
+          stream_event(%{
+            "tool_calls" => [%{"index" => index, "function" => %{"arguments" => head}}]
+          }),
+          stream_event(%{
+            "tool_calls" => [%{"index" => index, "function" => %{"arguments" => tail}}]
+          })
+        ]
+      end)
+
+    reasoning_events ++
+      call_events ++ [stream_event(%{}, "tool_calls"), usage_event(usage), "data: [DONE]\n\n"]
+  end
+
+  defp text_stream(fragments, usage) do
+    text_events = Enum.map(fragments, fn text -> stream_event(%{"content" => text}) end)
+
+    text_events ++ [stream_event(%{}, "stop"), usage_event(usage), "data: [DONE]\n\n"]
+  end
+
+  defp consume(stream) do
+    Enum.reduce(stream, %{text: "", types: [], done: nil, tool_calls: []}, fn chunk, acc ->
+      acc = %{acc | types: acc.types ++ [chunk.type]}
+
+      case chunk do
+        %StreamChunk{type: :text_delta, text: text} ->
+          %{acc | text: acc.text <> text}
+
+        %StreamChunk{type: :tool_call, tool_calls: calls} ->
+          %{acc | tool_calls: acc.tool_calls ++ calls}
+
+        %StreamChunk{type: type} = chunk when type in [:done, :error] ->
+          %{acc | done: chunk}
+
+        _other ->
+          acc
+      end
+    end)
+  end
 end


### PR DESCRIPTION
## PR Series

| PR | Description |
|---|---|
| [#116](https://github.com/doofinder/llm_composer/pull/116) | Add StreamCollector — all four streaming providers (OpenAI, OpenRouter, Google, Bedrock) |
| **👉 [#117](https://github.com/doofinder/llm_composer/pull/117)** | **Add streaming support to Agent with `:tool_call` stream chunks** |
| [#118](https://github.com/doofinder/llm_composer/pull/118) | Docs and changelog for Agent streaming |

---

## Summary

- **Streaming agent loop**: `LlmComposer.Agent.run/3` now returns `{:ok, stream}` when `settings.stream_response` is `true`. The stream yields only the final answer's `:text_delta` chunks followed by a terminal `:done` chunk with cumulative `usage`/`cost_info` and the full `Agent.Result` in `metadata.agent_result`. Intermediate tool-calling turns run internally via `StreamCollector` (PR #116). Supported providers: `:open_ai`, `:open_router`, `:open_ai_responses`, `:google`, `:bedrock`, `:ollama` (native Ollama does not emit tool-call deltas; use `:open_ai` pointed at Ollama's OpenAI-compatible endpoint for tool-call streaming).

- **`:tool_call` stream chunk type**: After executing tool calls the agent emits one assembled `%StreamChunk{type: :tool_call}` chunk per call (result already filled in) before starting the next LLM turn. This makes the stream self-contained — callers can react to tool activity inline without attaching a telemetry handler:

  ```elixir
  %StreamChunk{type: :tool_call, tool_calls: [call]}, acc ->
    IO.puts("[tool] #{call.name} → #{inspect(call.result)}")
    acc
  ```

- **Telemetry**: `[:llm_composer, :agent, :tool, :start]` now includes `:arguments`, `:metadata`, and `:id`. A new `[:llm_composer, :agent, :reasoning, :delta]` event surfaces intermediate reasoning. Pass `telemetry_metadata:` to `run/3` to scope all events to a single run via an auto-generated `:run_id`.

- **Dialyzer fix**: removed unreachable fallback clause in `user_prompt/2` (`Settings.user_prompt_prefix` is always a `String.t()`).

## Bug fixes

- **Tool result encoding crash**: `FunctionCallHelpers.build_tool_result_messages/1` used `to_string/1` on tool results, raising `Protocol.UndefinedError` for any tool returning a map, list, or struct. Results are now JSON-encoded via `Helpers.json_engine()` with an `inspect/1` fallback.

- **`:max_iterations_reached` discards accumulated work**: the loop returned a bare `{:error, :max_iterations_reached}`, throwing away `cost_infos`, `function_calls`, and the partial conversation. Now returns `{:error, {:max_iterations_reached, %{cost_infos, function_calls, messages, iterations}}}`. The streaming path includes the same data in the error chunk metadata.

- **`functions_from_settings/1` only read the first provider**: in a multi-provider fallback setup, only the first provider's `:functions` were used. Now merges functions from all providers and deduplicates by name.

- **Logger metadata not propagated in parallel tool execution**: `Task.async_stream` workers in `:parallel` mode didn't inherit the caller's `Logger.metadata/0`. Parent metadata is now captured and restored inside each worker.

## Test plan

- [x] `mix test test/llm_composer/agent_test.exs`
- [x] `mix precommit`
- [x] Smoke tested against OpenAI, OpenAI Responses (gpt-5-mini), OpenRouter, and Bedrock via `samples/loop_agent_all_providers_stream.ex`